### PR TITLE
fix: scroll to stopped line during debugging

### DIFF
--- a/src/SharpIDE.Godot/Features/CodeEditor/CodeEditorPanel.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/CodeEditorPanel.cs
@@ -186,6 +186,8 @@ public partial class CodeEditorPanel : MarginContainer
 			var tabForStopInfo = _tabContainer.GetChildren().OfType<SharpIdeCodeEdit>().Single(t => t.SharpIdeFile.Path == executionStopInfo.FilePath);
 			tabForStopInfo.SetLineBackgroundColor(lineInt, ExecutingLineColor);
 			tabForStopInfo.SetLineAsExecuting(lineInt, true);
+			var fileLinePosition = new SharpIdeFileLinePosition(lineInt, 0);
+			tabForStopInfo.SetFileLinePosition(fileLinePosition);
 		});
 	}
 	


### PR DESCRIPTION

<!-- PR description above this line -->
#
> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/SharpIDE/blob/main/CONTRIBUTING.md#legal-notice)
Fixes #53 
Added call to `SetFileLinePosition` in `CodeEditorPanel` to scroll the editor to the stopped line during debugging.