### PR TITLE
Eat all whitespace characters on backspace

### DIFF
--- a/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit.cs
@@ -439,10 +439,22 @@ public partial class SharpIdeCodeEdit : CodeEdit
 		int startCol = i + 1; // Start of line
 		
 		if (startCol >= col) return; // No whitespace to remove
+
+		var text = Text;
 		int globalIndex = 0;
-		for (int ln = 0; ln < line; ln++)
-			globalIndex += GetLine(ln).Length + 1; // +1 for newline
-		globalIndex += startCol;
+		int currentLine = 0;
+		
+		for (int j = 0; j < text.Length; j++)
+		{
+			if (currentLine == line)
+			{
+				globalIndex = j + startCol;
+				break;
+			}
+			if (text[j] == '\n')
+				currentLine++;
+		}
+		
 		int deleteLen = col - startCol;
 
 		ComplexOperation(() =>


### PR DESCRIPTION
I do not like having to individually backspace every whitespace character so this pr fixes that. I was not really sure where to put the backspace key check so I just put it at the top in `_GuiInput`.

Update: Caret now moves to previous line as well as all whitespace being removed. (Video updated)

#### Before
[Before.webm](https://github.com/user-attachments/assets/7d2ff057-f888-48c5-a331-768a9f41fd33)

#### After
[After2.webm](https://github.com/user-attachments/assets/51ff9e2f-ded9-436a-8d60-db3374ce7eb9)

<!-- PR description above this line -->
#
> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/SharpIDE/blob/main/CONTRIBUTING.md#legal-notice)
