### PR TITLE
🐛 CodeEdit - Fix ArgumentOutOfRangeException on multiline removal

### DIFF
--- a/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit.cs
@@ -151,8 +151,15 @@ public partial class SharpIdeCodeEdit : CodeEdit
 		if (_settingWholeDocumentTextSuppressLineEditsEvent) return;
 		var fromLineText = GetLine((int)fromLine);
 		var caretPosition = this.GetCaretPosition();
-		var textFrom0ToCaret = fromLineText[..caretPosition.col];
 		var caretPositionEnum = LineEditOrigin.Unknown;
+
+		if (caretPosition.line != (int)fromLine || caretPosition.col < 0 || caretPosition.col > fromLineText.Length)
+		{
+			_syntaxHighlighter.LinesChanged(fromLine, toLine, caretPositionEnum);
+			return;
+		}
+
+		var textFrom0ToCaret = fromLineText[..caretPosition.col];
 		if (string.IsNullOrWhiteSpace(textFrom0ToCaret))
 		{
 			caretPositionEnum = LineEditOrigin.StartOfLine;


### PR DESCRIPTION
@MattParkerDev edit: This fixes an exception caused by multi-line removal, most reproducible using Ctrl X on a selection of 2 whole lines.

```
ERROR: System.ArgumentOutOfRangeException: Index and length must refer to a location within the string. (Parameter 'length')
   at System.String.ThrowSubstringArgumentOutOfRange(Int32 startIndex, Int32 length)
   at System.String.Substring(Int32 startIndex, Int32 length)
   at SharpIDE.Godot.Features.CodeEditor.SharpIdeCodeEdit.OnLinesEditedFrom(Int64 fromLine, Int64 toLine) in C:\Users\Matthew\Documents\Git\SharpIDE\src\SharpIDE.Godot\Features\CodeEditor\SharpIdeCodeEdit.cs:line 154
   at Godot.TextEdit.LinesEditedFromTrampoline(Object delegateObj, NativeVariantPtrArgs args, godot_variant& ret) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/TextEdit.cs:line 3714
   at Godot.DelegateUtils.InvokeWithVariantArgs(IntPtr delegateGCHandle, Void* trampoline, godot_variant** args, Int32 argc, godot_variant* outRet) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs:line 86
   at: void Godot.NativeInterop.ExceptionUtils.LogException(System.Exception) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs:113)
   C# backtrace (most recent call first):
       [0] void Godot.GD.PushError(string) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs:366)
       [1] void Godot.NativeInterop.ExceptionUtils.LogException(System.Exception) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs:113)
       [2] void Godot.DelegateUtils.InvokeWithVariantArgs(nint, System.Void*, Godot.NativeInterop.godot_variant**, int, Godot.NativeInterop.godot_variant*) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs:86)
```

Original description:
> This PR fixes an out of bounds error by adding some condition checks before doing the problematic line `var textFrom0ToCaret = fromLineText[..caretPosition.col];` in `SharpIdeCodeEdit.cs`. The error can be reproduced by spamming text, undo, redo and select operations all at the same time.

> The video below demonstrates the bug. In the video the condition triggers when I do a select operation but this isn't always the case, sometimes the condition triggers when just doing undo's and lots of text.

> [Showing bug.webm](https://github.com/user-attachments/assets/139ba404-d9a2-4586-9f76-72a6e17ce901)

<!-- PR description above this line -->
#
> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/SharpIDE/blob/main/CONTRIBUTING.md#legal-notice)
