### PR TITLE
✨ Allow users to import their own background image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,8 +368,8 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-.vscode/launch.json
-.vscode/tasks.json
+**/.vscode/launch.json
+**/.vscode/tasks.json
 
 # Rider
 .idea/

--- a/src/SharpIDE.Godot/Features/CodeEditor/CodeEditorPanel.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/CodeEditorPanel.cs
@@ -21,9 +21,11 @@ public partial class CodeEditorPanel : MarginContainer
 	private PackedScene _sharpIdeCodeEditScene = GD.Load<PackedScene>("res://Features/CodeEditor/SharpIdeCodeEdit.tscn");
 	private TabContainer _tabContainer = null!;
 	private ConcurrentDictionary<SharpIdeProjectModel, ExecutionStopInfo> _debuggerExecutionStopInfoByProject = [];
+	private TextureRect? _backgroundTextureRect;
 	
 	[Inject] private readonly RunService _runService = null!;
 	[Inject] private readonly SharpIdeMetadataAsSourceService _sharpIdeMetadataAsSourceService = null!;
+	
 	public override void _Ready()
 	{
 		_tabContainer = GetNode<TabContainer>("TabContainer");
@@ -34,6 +36,9 @@ public partial class CodeEditorPanel : MarginContainer
 		tabBar.TabClosePressed += OnTabClosePressed;
 		GlobalEvents.Instance.DebuggerExecutionStopped.Subscribe(OnDebuggerExecutionStopped);
 		GlobalEvents.Instance.ProjectStoppedDebugging.Subscribe(OnProjectStoppedDebugging);
+		GodotGlobalEvents.Instance.BackgroundImageChanged.Subscribe(OnBackgroundImageChanged);
+		GodotGlobalEvents.Instance.BackgroundTransparencyChanged.Subscribe(OnBackgroundTransparencyChanged);
+		InitializeBackgroundImage();
 	}
 
 	public override void _GuiInput(InputEvent @event)
@@ -241,6 +246,74 @@ public partial class CodeEditorPanel : MarginContainer
 			tabForStopInfo.SetLineAsExecuting(godotLine, false);
 			tabForStopInfo.SetLineColour(godotLine);
 		});
+	}
+
+	private void InitializeBackgroundImage()
+	{
+		var imagePath = Singletons.AppState.IdeSettings.BackgroundImagePath;
+		if (string.IsNullOrEmpty(imagePath)) return;
+
+		UpdateBackgroundImage(imagePath);
+	}
+
+	private Task OnBackgroundImageChanged(string imagePath)
+	{
+		UpdateBackgroundImage(imagePath);
+		return Task.CompletedTask;
+	}
+
+	private void UpdateBackgroundImage(string imagePath)
+	{
+		// Remove existing background if any
+		if (_backgroundTextureRect != null)
+		{
+			RemoveChild(_backgroundTextureRect);
+			_backgroundTextureRect.QueueFree();
+			_backgroundTextureRect = null;
+		}
+
+		if (string.IsNullOrEmpty(imagePath)) return;
+
+		// Load the texture
+		Texture2D? tex = null;
+		if (File.Exists(imagePath))
+		{
+			var image = Image.LoadFromFile(imagePath);
+			if (image != null)
+			{
+				tex = ImageTexture.CreateFromImage(image);
+			}
+		}
+
+		if (tex == null) return;
+
+		_backgroundTextureRect = new TextureRect
+		{
+			Texture = tex,
+			ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
+			StretchMode = TextureRect.StretchModeEnum.KeepAspectCovered,
+			MouseFilter = MouseFilterEnum.Ignore
+		};
+
+		AddChild(_backgroundTextureRect);
+		MoveChild(_backgroundTextureRect, 0); // Move behind TabContainer
+		
+		UpdateBackgroundTransparency(Singletons.AppState.IdeSettings.BackgroundImageTransparency);
+	}
+
+	private Task OnBackgroundTransparencyChanged(double transparency)
+	{
+		UpdateBackgroundTransparency(transparency);
+		return Task.CompletedTask;
+	}
+
+	private void UpdateBackgroundTransparency(double transparency)
+	{
+		if (_backgroundTextureRect == null) return;
+
+		var color = _backgroundTextureRect.Modulate;
+		color.A = 1 - (float)transparency;
+		_backgroundTextureRect.Modulate = color;
 	}
 }
 

--- a/src/SharpIDE.Godot/Features/CodeEditor/CustomSyntaxHighlighter.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/CustomSyntaxHighlighter.cs
@@ -29,6 +29,13 @@ public partial class CustomHighlighter : SyntaxHighlighter
         };
     }
     
+    private Color ApplyTransparency(Color color)
+    {
+        var transparency = (float)Singletons.AppState.IdeSettings.CodeBackgroundTransparency;
+        color.A = 1f - transparency;
+        return color;
+    }
+    
     
     public void SetHighlightingData(ImmutableArray<SharpIdeClassifiedSpan> classifiedSpans, ImmutableArray<SharpIdeRazorClassifiedSpan> razorClassifiedSpans)
     {
@@ -160,7 +167,7 @@ public partial class CustomHighlighter : SyntaxHighlighter
             
             var highlightInfo = new Dictionary
             {
-                { ColorStringName, GetColorForRazorSpanKind(razorSpan.Kind, razorSpan.CodeClassificationType, razorSpan.VsSemanticRangeType) }
+                { ColorStringName, ApplyTransparency(GetColorForRazorSpanKind(razorSpan.Kind, razorSpan.CodeClassificationType, razorSpan.VsSemanticRangeType)) }
             };
 
             highlights[columnIndex] = highlightInfo;
@@ -226,7 +233,7 @@ public partial class CustomHighlighter : SyntaxHighlighter
             // Build the highlight entry
             var highlightInfo = new Dictionary
             {
-                { ColorStringName, ClassificationToColorMapper.GetColorForClassification(ColourSetForTheme, classifiedSpans.Single().ClassificationType) }
+                { ColorStringName, ApplyTransparency(ClassificationToColorMapper.GetColorForClassification(ColourSetForTheme, classifiedSpans.Single().ClassificationType)) }
             };
 
             highlights[columnIndex] = highlightInfo;

--- a/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit.cs
@@ -89,6 +89,9 @@ public partial class SharpIdeCodeEdit : CodeEdit
 		LinesEditedFrom += OnLinesEditedFrom;
 		GlobalEvents.Instance.SolutionAltered.Subscribe(OnSolutionAltered);
 		GodotGlobalEvents.Instance.TextEditorThemeChanged.Subscribe(UpdateEditorThemeAsync);
+		GodotGlobalEvents.Instance.BackgroundTransparencyChanged.Subscribe(OnBackgroundTransparencyChangedAsync);
+		GodotGlobalEvents.Instance.CodeBackgroundTransparencyChanged.Subscribe(OnCodeBackgroundTransparencyChangedAsync);
+		GodotGlobalEvents.Instance.CurrentLineHighlightColorChanged.Subscribe(OnCurrentLineHighlightColorChangedAsync);
 		SetCodeRegionTags("#region", "#endregion");
 		//AddGitGutter();
 		var hScrollBar = GetHScrollBar();

--- a/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit_Theme.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit_Theme.cs
@@ -7,6 +7,7 @@ public partial class SharpIdeCodeEdit
 {
     private static readonly StringName ThemeInfoStringName = "ThemeInfo";
     private static readonly StringName IsLight1OrDark2StringName = "IsLight1OrDark2";
+    private static readonly StringName CurrentLineColorStringName = "current_line_color";
 
     private void UpdateEditorThemeForCurrentTheme()
     {
@@ -25,5 +26,43 @@ public partial class SharpIdeCodeEdit
         _syntaxHighlighter.UpdateThemeColorCache(lightOrDarkTheme);
         SyntaxHighlighter = null;
         SyntaxHighlighter = _syntaxHighlighter; // Reassign to trigger redraw
+        MakeEditorTransparent();
+        ApplyCurrentLineHighlightColor();
+    }
+
+    private void MakeEditorTransparent()
+    {
+        var codeEditStyle = (StyleBoxFlat)GetThemeStylebox("normal");
+        var bgColor = codeEditStyle.BgColor;
+        bgColor.A = 0f;
+        codeEditStyle.BgColor = bgColor;
+    }
+
+    private Task OnBackgroundTransparencyChangedAsync(double transparency)
+    {
+        MakeEditorTransparent();
+        return Task.CompletedTask;
+    }
+
+    private Task OnCodeBackgroundTransparencyChangedAsync(double transparency)
+    {
+        // Force the syntax highlighter to redraw itself
+        var syntaxHighlighter = SyntaxHighlighter;
+        SyntaxHighlighter = null;
+        SyntaxHighlighter = syntaxHighlighter;
+        return Task.CompletedTask;
+    }
+
+    private Task OnCurrentLineHighlightColorChangedAsync(Color color)
+    {
+        ApplyCurrentLineHighlightColor();
+        return Task.CompletedTask;
+    }
+
+    private void ApplyCurrentLineHighlightColor()
+    {
+        var colorString = Singletons.AppState.IdeSettings.CurrentLineHighlightColor;
+        var color = new Color(colorString);
+        AddThemeColorOverride(CurrentLineColorStringName, color);
     }
 }

--- a/src/SharpIDE.Godot/Features/IdeSettings/AppState.cs
+++ b/src/SharpIDE.Godot/Features/IdeSettings/AppState.cs
@@ -16,6 +16,10 @@ public class IdeSettings
     public bool DebuggerUseSharpDbg { get; set; } = true;
     public float UiScale { get; set; } = 1.0f;
     public LightOrDarkTheme Theme { get; set; } = LightOrDarkTheme.Dark;
+    public string BackgroundImagePath { get; set; } = "";
+    public double BackgroundImageTransparency { get; set; } = 0.7;
+    public double CodeBackgroundTransparency { get; set; } = 0.05;
+    public string CurrentLineHighlightColor { get; set; } = "#0f0f0f";
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/src/SharpIDE.Godot/Features/Settings/SettingsWindow.cs
+++ b/src/SharpIDE.Godot/Features/Settings/SettingsWindow.cs
@@ -1,4 +1,5 @@
 using Godot;
+using System;
 using SharpIDE.Godot.Features.IdeSettings;
 
 namespace SharpIDE.Godot.Features.Settings;
@@ -9,6 +10,12 @@ public partial class SettingsWindow : Window
     private LineEdit _debuggerFilePathLineEdit = null!;
     private CheckButton _debuggerUseSharpDbgCheckButton = null!;
     private OptionButton _themeOptionButton = null!;
+    private LineEdit _backgroundImageLineEdit = null!;
+    private Button _backgroundImageSelectBtn = null!;
+    private HSlider _backgroundImageTransparencySlider = null!;
+    private HSlider _codeBackgroundTransparencySlider = null!;
+    private FileDialog _fileDialog = null!;
+    private ColorPickerButton _currentLineHighlightColorPickerButton = null!;
     
     public override void _Ready()
     {
@@ -17,11 +24,30 @@ public partial class SettingsWindow : Window
         _debuggerFilePathLineEdit = GetNode<LineEdit>("%DebuggerFilePathLineEdit");
         _debuggerUseSharpDbgCheckButton = GetNode<CheckButton>("%DebuggerUseSharpDbgCheckButton");
         _themeOptionButton = GetNode<OptionButton>("%ThemeOptionButton");
+        _backgroundImageLineEdit = GetNode<LineEdit>("%BackgroundImageLineEdit");
+        _backgroundImageSelectBtn = GetNode<Button>("%BackgroundImageSelectBtn");
+        _backgroundImageTransparencySlider = GetNode<HSlider>("%BackgroundImageTransparencySlider");
+        _codeBackgroundTransparencySlider = GetNode<HSlider>("%CodeBackgroundTransparencySlider");
+        _currentLineHighlightColorPickerButton = GetNode<ColorPickerButton>("%CurrentLineHighlightColorPickerButton");
+        _currentLineHighlightColorPickerButton.EditAlpha = true;
+        _fileDialog = new FileDialog
+        {
+            Access = FileDialog.AccessEnum.Filesystem,
+            CurrentDir = System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyPictures),
+            FileMode = FileDialog.FileModeEnum.OpenFile,
+            Filters = ["*.png, *.jpg, *.jpeg, *.svg, *.bmp, *.webp ; Image Files"]
+        };
         _uiScaleSpinBox.ValueChanged += OnUiScaleSpinBoxValueChanged;
         _debuggerFilePathLineEdit.TextChanged += OnDebuggerFilePathChanged;
         _debuggerUseSharpDbgCheckButton.Toggled += OnDebuggerUseSharpDbgToggled;
         _themeOptionButton.ItemSelected += OnThemeItemSelected;
+        _backgroundImageSelectBtn.Pressed += OnBackgroundImageSelectBtnPressed;
+        _backgroundImageTransparencySlider.ValueChanged += OnBackgroundImageTransparencySliderChanged;
+        _codeBackgroundTransparencySlider.ValueChanged += OnCodeBackgroundTransparencySliderChanged;
+        _currentLineHighlightColorPickerButton.ColorChanged += OnCurrentLineHighlightColorChanged;
+        _fileDialog.FileSelected += OnFileDialogFileSelected;
         AboutToPopup += OnAboutToPopup;
+        AddChild(_fileDialog);
     }
 
     private void OnAboutToPopup()
@@ -31,12 +57,17 @@ public partial class SettingsWindow : Window
         _debuggerUseSharpDbgCheckButton.ButtonPressed = Singletons.AppState.IdeSettings.DebuggerUseSharpDbg;
         var themeOptionIndex = _themeOptionButton.GetOptionIndexOrNullForString(Singletons.AppState.IdeSettings.Theme.ToString());
         if (themeOptionIndex is not null) _themeOptionButton.Selected = themeOptionIndex.Value;
+        _backgroundImageLineEdit.Text = Singletons.AppState.IdeSettings.BackgroundImagePath;
+        _backgroundImageTransparencySlider.Value = Singletons.AppState.IdeSettings.BackgroundImageTransparency;
+        _codeBackgroundTransparencySlider.Value = Singletons.AppState.IdeSettings.CodeBackgroundTransparency;
+        _currentLineHighlightColorPickerButton.Color = new Color(Singletons.AppState.IdeSettings.CurrentLineHighlightColor);
     }
 
     private void OnUiScaleSpinBoxValueChanged(double value)
     {
         var valueFloat = (float)value;
         Singletons.AppState.IdeSettings.UiScale = valueFloat;
+        AppStateLoader.SaveAppStateToConfigFile(Singletons.AppState);
         
         GetTree().GetRoot().ContentScaleFactor = valueFloat;
         PopupCenteredRatio(0.5f); // Re-size the window after scaling
@@ -45,11 +76,13 @@ public partial class SettingsWindow : Window
     private void OnDebuggerFilePathChanged(string newText)
     {
         Singletons.AppState.IdeSettings.DebuggerExecutablePath = newText;
+        AppStateLoader.SaveAppStateToConfigFile(Singletons.AppState);
     }
     
     private void OnDebuggerUseSharpDbgToggled(bool pressed)
     {
         Singletons.AppState.IdeSettings.DebuggerUseSharpDbg = pressed;
+        AppStateLoader.SaveAppStateToConfigFile(Singletons.AppState);
     }
     
     private void OnThemeItemSelected(long index)
@@ -62,7 +95,42 @@ public partial class SettingsWindow : Window
             _ => throw new InvalidOperationException($"Unknown theme selected: {selectedTheme}")
         };
         Singletons.AppState.IdeSettings.Theme = lightOrDarkTheme;
+        AppStateLoader.SaveAppStateToConfigFile(Singletons.AppState);
         this.SetIdeTheme(lightOrDarkTheme);
         GodotGlobalEvents.Instance.TextEditorThemeChanged.InvokeParallelFireAndForget(lightOrDarkTheme);
+    }
+
+    private void OnBackgroundImageSelectBtnPressed()
+    {
+        _fileDialog.PopupCentered();
+    }
+
+    private void OnFileDialogFileSelected(string path)
+    {
+        _backgroundImageLineEdit.Text = path;
+        Singletons.AppState.IdeSettings.BackgroundImagePath = path;
+        AppStateLoader.SaveAppStateToConfigFile(Singletons.AppState);
+        GodotGlobalEvents.Instance.BackgroundImageChanged.InvokeParallelFireAndForget(path);
+    }
+
+    private void OnBackgroundImageTransparencySliderChanged(double newValue)
+    {
+        Singletons.AppState.IdeSettings.BackgroundImageTransparency = newValue;
+        AppStateLoader.SaveAppStateToConfigFile(Singletons.AppState);
+        GodotGlobalEvents.Instance.BackgroundTransparencyChanged.InvokeParallelFireAndForget(newValue);
+    }
+
+    private void OnCodeBackgroundTransparencySliderChanged(double newValue)
+    {
+        Singletons.AppState.IdeSettings.CodeBackgroundTransparency = newValue;
+        AppStateLoader.SaveAppStateToConfigFile(Singletons.AppState);
+        GodotGlobalEvents.Instance.CodeBackgroundTransparencyChanged.InvokeParallelFireAndForget(newValue);
+    }
+
+    private void OnCurrentLineHighlightColorChanged(Color color)
+    {
+        Singletons.AppState.IdeSettings.CurrentLineHighlightColor = color.ToHtml();
+        AppStateLoader.SaveAppStateToConfigFile(Singletons.AppState);
+        GodotGlobalEvents.Instance.CurrentLineHighlightColorChanged.InvokeParallelFireAndForget(color);
     }
 }

--- a/src/SharpIDE.Godot/Features/Settings/SettingsWindow.tscn
+++ b/src/SharpIDE.Godot/Features/Settings/SettingsWindow.tscn
@@ -155,3 +155,101 @@ layout_mode = 2
 layout_mode = 2
 theme_type_variation = &"Gray500Label"
 text = "The Light theme is experimental, and may contain visual inconsistencies/glitches"
+
+[node name="VBoxContainer5" type="VBoxContainer" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2" unique_id=1007606942]
+layout_mode = 2
+theme_override_constants/separation = 2
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer5" unique_id=2024377048]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer5/HBoxContainer2" unique_id=1649629266]
+layout_mode = 2
+text = "Background Image"
+
+[node name="BackgroundImageLineEdit" type="LineEdit" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer5/HBoxContainer2" unique_id=392549596]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+editable = false
+
+[node name="BackgroundImageSelectBtn" type="Button" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer5/HBoxContainer2" unique_id=77243447]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Select"
+
+[node name="Label2" type="Label" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer5" unique_id=1432013284]
+layout_mode = 2
+theme_type_variation = &"Gray500Label"
+text = "Change the background image."
+
+[node name="VBoxContainer6" type="VBoxContainer" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2" unique_id=358197057]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer6" unique_id=1788181380]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer6/HBoxContainer" unique_id=182831859]
+layout_mode = 2
+text = "Background Transparency"
+
+[node name="BackgroundImageTransparencySlider" type="HSlider" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer6/HBoxContainer" unique_id=1062301543]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.01
+value = 0.7
+
+[node name="Label2" type="Label" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer6" unique_id=1859335402]
+layout_mode = 2
+theme_type_variation = &"Gray500Label"
+text = "Change the background images transparency."
+
+[node name="VBoxContainer7" type="VBoxContainer" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2" unique_id=724859160]
+layout_mode = 2
+theme_override_constants/separation = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer7" unique_id=1973428951]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer7/HBoxContainer" unique_id=805517832]
+layout_mode = 2
+text = "Current Line Highlight Color"
+
+[node name="CurrentLineHighlightColorPickerButton" type="ColorPickerButton" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer7/HBoxContainer" unique_id=392847619]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+color = Color(0.0588235, 0.0588235, 0.0588235, 1)
+edit_alpha = false
+
+[node name="Label2" type="Label" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer7" unique_id=1528364002]
+layout_mode = 2
+theme_type_variation = &"Gray500Label"
+text = "The color used to highlight the current line in the code editor."
+
+[node name="VBoxContainer8" type="VBoxContainer" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2" unique_id=1827465392]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer8" unique_id=1563928471]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer8/HBoxContainer" unique_id=784629512]
+layout_mode = 2
+text = "Code Transparency"
+
+[node name="CodeBackgroundTransparencySlider" type="HSlider" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer8/HBoxContainer" unique_id=1947362853]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.01
+value = 0.05
+
+[node name="Label2" type="Label" parent="HSplitContainer/PanelContainer/MarginContainer/VBoxContainer2/VBoxContainer8" unique_id=1738294650]
+layout_mode = 2
+theme_type_variation = &"Gray500Label"
+text = "Adjust the transparency of code."

--- a/src/SharpIDE.Godot/GodotGlobalEvents.cs
+++ b/src/SharpIDE.Godot/GodotGlobalEvents.cs
@@ -15,4 +15,8 @@ public class GodotGlobalEvents
     public EventWrapper<SharpIdeFile, SharpIdeFileLinePosition?, Task> FileSelected { get; } = new((_, _) => Task.CompletedTask);
     public EventWrapper<SharpIdeFile, SharpIdeFileLinePosition?, Task> FileExternallySelected { get; } = new((_, _) => Task.CompletedTask);
     public EventWrapper<LightOrDarkTheme, Task> TextEditorThemeChanged { get; } = new(_ => Task.CompletedTask);
+    public EventWrapper<string, Task> BackgroundImageChanged { get; } = new(_ => Task.CompletedTask);
+    public EventWrapper<double, Task> BackgroundTransparencyChanged { get; } = new(_ => Task.CompletedTask);
+    public EventWrapper<double, Task> CodeBackgroundTransparencyChanged { get; } = new(_ => Task.CompletedTask);
+    public EventWrapper<global::Godot.Color, Task> CurrentLineHighlightColorChanged { get; } = new(_ => Task.CompletedTask);
 }


### PR DESCRIPTION
> [!NOTE]
> PR was recreated on my main account instead of from an organization because of a GitHub bug that did not allow edits by maintainers.

This PR allows users to add their own background image with some other settings and it fixes settings not getting saved.

### Todo
- [x] Make this work with any kind of image of any size
- [x] Add option to import background picture and change background transparency in settings
- [x] Add option to change current line highlight color in settings
- [x] Add option to change code transparency

### Preview
<img width="1632" height="877" alt="image" src="https://github.com/user-attachments/assets/902ff438-3614-42b3-af9c-afdce7f6e0b0" />

<img width="832" height="496" alt="image" src="https://github.com/user-attachments/assets/da651057-daa6-473d-8dc8-230128e3a100" />

<img width="832" height="496" alt="image" src="https://github.com/user-attachments/assets/e8dac3f4-6bba-4e11-925b-3e983f28a007" />

#### Maybe the background image should go behind all windows like Doki Doki VSCode extension does it?

<img width="2544" height="1360" alt="image" src="https://github.com/user-attachments/assets/80728c7d-3de3-4dc1-a48a-bf87d34a3a88" />

<!-- PR description above this line -->
#
> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/SharpIDE/blob/main/CONTRIBUTING.md#legal-notice)
