### PR TITLE
CI: build for each commit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,16 +1,27 @@
-name: Create GitHub Release
+name: Build & Create GitHub Release
 on:
   push:
-    branches:
-      - main
+  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: write # Required to create releases
 
 jobs:
-  execute-parallel-pipeline:
+  build-check:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-dotnet@v5
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    needs: [build-check]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-dotnet@v5


### PR DESCRIPTION
This way GitHub will check if contributor's PRs still build, without the need to create a release.

> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/SharpIDE/blob/main/CONTRIBUTING.md#legal-notice)
