### PR TITLE
add TextMate engine and .vsix import

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,6 +59,7 @@
     <PackageVersion Include="Photino.Blazor" Version="4.0.13" />
     <PackageVersion Include="R3" Version="1.3.0" />
     <PackageVersion Include="SharpDbg" Version="0.1.0-preview8" />
+    <PackageVersion Include="TextMateSharp" Version="2.0.3" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.0" />
     <PackageVersion Include="XtermBlazor" Version="2.2.0" />
   </ItemGroup>

--- a/src/SharpIDE.Application/DependencyInjection.cs
+++ b/src/SharpIDE.Application/DependencyInjection.cs
@@ -8,6 +8,7 @@ using SharpIDE.Application.Features.Evaluation;
 using SharpIDE.Application.Features.FilePersistence;
 using SharpIDE.Application.Features.FileSystem;
 using SharpIDE.Application.Features.FileWatching;
+using SharpIDE.Application.Features.LanguageExtensions;
 using SharpIDE.Application.Features.NavigationHistory;
 using SharpIDE.Application.Features.Nuget;
 using SharpIDE.Application.Features.Run;
@@ -46,6 +47,8 @@ public static class DependencyInjection
 		services.AddScoped<DotnetTemplateService>();
 		services.AddScoped<SharpIdeSolutionService>();
 		services.AddScoped<FileSystemService>();
+		services.AddSingleton<LanguageExtensionRegistry>();
+		services.AddScoped<ExtensionInstaller>();
 		services.AddLogging();
 		return services;
 	}

--- a/src/SharpIDE.Application/Features/FileWatching/IdeFileOperationsService.cs
+++ b/src/SharpIDE.Application/Features/FileWatching/IdeFileOperationsService.cs
@@ -72,9 +72,18 @@ public class IdeFileOperationsService(SharpIdeRootFolderModificationService root
 		await _rootFolderModificationService.RemoveFile(file);
 	}
 
+    public async Task<SharpIdeFile> CreateGenericFile(SharpIdeFolder parentFolder, string fileName)
+	{
+		var newFilePath = Path.Combine(parentFolder.ChildNodeBasePath, fileName);
+		if (File.Exists(newFilePath)) throw new InvalidOperationException($"File {newFilePath} already exists.");
+		using var _ = await _ideFileExternalChangeHandler.IdeChangeLock.LockAsync();
+		await File.WriteAllTextAsync(newFilePath, string.Empty);
+		return await _rootFolderModificationService.CreateFile(parentFolder, newFilePath, fileName, string.Empty);
+	}
+
 	public async Task<SharpIdeFile> CreateCsFile(SharpIdeFolder parentFolder, string newFileName, string typeKeyword)
 	{
-		var newFilePath = Path.Combine(parentFolder.Path, newFileName);
+		var newFilePath = Path.Combine(parentFolder.ChildNodeBasePath, newFileName);
 		if (File.Exists(newFilePath)) throw new InvalidOperationException($"File {newFilePath} already exists.");
 		var className = Path.GetFileNameWithoutExtension(newFileName);
 		var @namespace = NewFileTemplates.ComputeNamespace(parentFolder);

--- a/src/SharpIDE.Application/Features/LanguageExtensions/ExtensionInstaller.cs
+++ b/src/SharpIDE.Application/Features/LanguageExtensions/ExtensionInstaller.cs
@@ -1,0 +1,197 @@
+using System.IO.Compression;
+using Microsoft.Extensions.Logging;
+
+namespace SharpIDE.Application.Features.LanguageExtensions;
+
+/// <summary>
+/// Installs and uninstalls VS Code and Visual Studio language extensions (.vsix packages).
+///
+/// Install:
+///   1. Parse the .vsix via VsixPackageParser
+///   2. Extract grammar files + optional LSP server to %APPDATA%/SharpIDE/extensions/<id>/
+///   3. Update grammar file paths to absolute paths
+///   4. Register in LanguageExtensionRegistry + persist
+///
+/// Uninstall:
+///   1. Unregister from LanguageExtensionRegistry
+///   2. Delete the extracted directory
+///   3. Persist updated registry
+/// </summary>
+public class ExtensionInstaller(LanguageExtensionRegistry registry, ILogger<ExtensionInstaller> logger)
+{
+    private static readonly string[] GrammarExtensions =
+        [".tmLanguage", ".tmGrammar", ".tmLanguage.json", ".tmGrammar.json", ".json"];
+
+    /// <summary>
+    /// Installs a .vsix file. Returns the registered InstalledExtension.
+    /// Throws on parse errors; logs and swaps to partial-success on extraction errors.
+    /// </summary>
+    public InstalledExtension Install(string vsixPath)
+    {
+        logger.LogInformation("Installing extension from {VsixPath}", vsixPath);
+
+        // 1. Parse metadata (still relative paths inside ZIP)
+        var parsed = VsixPackageParser.Parse(vsixPath);
+
+        // 2. Prepare extraction directory
+        var extensionsBase = LanguageExtensionPersistence.GetExtensionsBaseDirectory();
+        var extractedPath = Path.Combine(extensionsBase, SanitizeId(parsed.Id));
+        Directory.CreateDirectory(extractedPath);
+
+        // 3. Extract relevant files from the ZIP
+        ExtractFiles(vsixPath, extractedPath, parsed);
+
+        // 4. Resolve grammar file paths to absolute
+        var resolvedGrammars = parsed.Grammars
+            .Select(g => new GrammarContribution
+            {
+                LanguageId = g.LanguageId,
+                ScopeName = g.ScopeName,
+                GrammarFilePath = Path.Combine(extractedPath, NormalizePath(g.GrammarFilePath))
+            })
+            .Where(g => File.Exists(g.GrammarFilePath))
+            .ToList();
+
+        if (resolvedGrammars.Count == 0 && parsed.Grammars.Count > 0)
+        {
+            // Grammar assets declared but not found after extraction — try scanning for .tmLanguage files
+            resolvedGrammars = ScanForGrammars(extractedPath, parsed);
+            logger.LogWarning(
+                "Grammar assets from manifest not found after extraction for {Id}; found {Count} by scanning",
+                parsed.Id, resolvedGrammars.Count);
+        }
+
+        if (resolvedGrammars.Count == 0)
+        {
+            TryDeleteDirectory(extractedPath);
+            throw new InvalidOperationException(
+                $"'{parsed.DisplayName}' does not contain any importable TextMate syntax files. " +
+                "SharpIDE can only import .vsix packages that bundle a TextMate grammar right now.");
+        }
+
+        // 5. Build the final InstalledExtension with absolute paths
+        var installed = new InstalledExtension
+        {
+            Id = parsed.Id,
+            Version = parsed.Version,
+            Publisher = parsed.Publisher,
+            DisplayName = parsed.DisplayName,
+            ExtractedPath = extractedPath,
+            PackageKind = parsed.PackageKind,
+            Languages = parsed.Languages,
+            Grammars = resolvedGrammars,
+        };
+
+        // 7. Register + persist
+        registry.Register(installed);
+        LanguageExtensionPersistence.Save(registry.GetAllExtensions());
+
+        logger.LogInformation(
+            "Installed '{DisplayName}' ({Id} v{Version}): {GrammarCount} grammar(s), {LangCount} extension(s)",
+            installed.DisplayName, installed.Id, installed.Version,
+            installed.Grammars.Count, installed.Languages.Sum(l => l.FileExtensions.Length));
+
+        return installed;
+    }
+
+    /// <summary>
+    /// Uninstalls an extension by ID, removing it from the registry and deleting its extracted files.
+    /// </summary>
+    public void Uninstall(string extensionId)
+    {
+        logger.LogInformation("Uninstalling extension {ExtensionId}", extensionId);
+
+        var existing = registry.GetAllExtensions()
+            .FirstOrDefault(e => string.Equals(e.Id, extensionId, StringComparison.OrdinalIgnoreCase));
+
+        if (existing == null)
+        {
+            logger.LogWarning("Extension {ExtensionId} not found; nothing to uninstall", extensionId);
+            return;
+        }
+
+        registry.Unregister(extensionId);
+        LanguageExtensionPersistence.Save(registry.GetAllExtensions());
+
+        if (Directory.Exists(existing.ExtractedPath))
+        {
+            try
+            {
+                Directory.Delete(existing.ExtractedPath, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to delete extension directory {Path}", existing.ExtractedPath);
+            }
+        }
+
+        logger.LogInformation("Uninstalled {ExtensionId}", extensionId);
+    }
+
+    private static void ExtractFiles(string vsixPath, string extractedPath, InstalledExtension parsed)
+    {
+        using var zip = ZipFile.OpenRead(vsixPath);
+
+        // Collect the set of paths to extract:
+        //  - All grammar assets declared in manifest
+        var grammarPaths = new HashSet<string>(
+            parsed.Grammars.Select(g => NormalizePath(g.GrammarFilePath)),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in zip.Entries)
+        {
+            if (entry.FullName.EndsWith('/')) continue; // directory entry
+
+            var shouldExtract =
+                grammarPaths.Contains(entry.FullName) ||
+                HasGrammarExtension(entry.Name);
+
+            if (!shouldExtract) continue;
+
+            var destinationPath = Path.Combine(extractedPath, entry.FullName.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            entry.ExtractToFile(destinationPath, overwrite: true);
+        }
+    }
+
+    private static List<GrammarContribution> ScanForGrammars(string directory, InstalledExtension parsed)
+    {
+        var languageId = parsed.Languages.FirstOrDefault()?.LanguageId ?? "unknown";
+
+        return Directory
+            .EnumerateFiles(directory, "*.tmLanguage*", SearchOption.AllDirectories)
+            .Where(f => f.EndsWith(".tmLanguage", StringComparison.OrdinalIgnoreCase) ||
+                        f.EndsWith(".tmLanguage.json", StringComparison.OrdinalIgnoreCase))
+            .Select(f => new GrammarContribution
+            {
+                LanguageId = languageId,
+                GrammarFilePath = f
+            })
+            .ToList();
+    }
+
+    private static bool HasGrammarExtension(string filename) =>
+        filename.EndsWith(".tmLanguage", StringComparison.OrdinalIgnoreCase) ||
+        filename.EndsWith(".tmLanguage.json", StringComparison.OrdinalIgnoreCase) ||
+        filename.EndsWith(".tmGrammar", StringComparison.OrdinalIgnoreCase) ||
+        filename.EndsWith(".tmGrammar.json", StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizePath(string path) =>
+        path.Replace('/', Path.DirectorySeparatorChar).TrimStart(Path.DirectorySeparatorChar);
+
+    private static string SanitizeId(string id) =>
+        string.Concat(id.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c));
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup only.
+        }
+    }
+}

--- a/src/SharpIDE.Application/Features/LanguageExtensions/InstalledExtension.cs
+++ b/src/SharpIDE.Application/Features/LanguageExtensions/InstalledExtension.cs
@@ -1,0 +1,45 @@
+namespace SharpIDE.Application.Features.LanguageExtensions;
+
+/// <summary>
+/// Represents an installed VS Code or Visual Studio language extension (.vsix package).
+/// </summary>
+public class InstalledExtension
+{
+    public required string Id { get; init; }
+    public required string Version { get; init; }
+    public required string Publisher { get; init; }
+    public required string DisplayName { get; init; }
+    public required string ExtractedPath { get; init; } // absolute path to extracted dir
+    public ExtensionPackageKind PackageKind { get; init; } = ExtensionPackageKind.VisualStudio;
+    public List<LanguageContribution> Languages { get; init; } = [];
+    public List<GrammarContribution> Grammars { get; init; } = [];
+}
+
+public enum ExtensionPackageKind
+{
+    VisualStudio = 0,
+    VSCode = 1
+}
+
+/// <summary>
+/// Associates file extensions (and optional filename/shebang patterns) with a language ID.
+/// Discovered from .pkgdef entries like [$RootKey$\Languages\File Extensions\.axaml].
+/// </summary>
+public class LanguageContribution
+{
+    public required string LanguageId { get; init; }           // e.g. "axaml"
+    public string[] FileExtensions { get; init; } = [];        // e.g. [".axaml"]
+    public string[] FileNames { get; init; } = [];             // e.g. ["Makefile"]
+    public string? FirstLinePattern { get; init; }             // regex for shebang detection
+}
+
+/// <summary>
+/// Associates a language ID with a TextMate grammar file.
+/// Discovered from vsixmanifest Asset Type="Microsoft.VisualStudio.TextMate.Grammar".
+/// </summary>
+public class GrammarContribution
+{
+    public required string LanguageId { get; init; }
+    public string ScopeName { get; init; } = string.Empty;
+    public required string GrammarFilePath { get; init; }      // absolute path after extraction
+}

--- a/src/SharpIDE.Application/Features/LanguageExtensions/LanguageExtensionPersistence.cs
+++ b/src/SharpIDE.Application/Features/LanguageExtensions/LanguageExtensionPersistence.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SharpIDE.Application.Features.LanguageExtensions;
+
+/// <summary>
+/// Loads and saves the installed extensions registry to disk.
+/// Storage: %APPDATA%/SharpIDE/extensions/registry.json
+/// </summary>
+public static class LanguageExtensionPersistence
+{
+    private const string ExtensionsBaseDirectoryOverrideEnvironmentVariable = "SHARPIDE_EXTENSIONS_BASE_DIRECTORY";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private static string GetRegistryPath()
+    {
+        return Path.Combine(GetExtensionsBaseDirectory(), "registry.json");
+    }
+
+    public static string GetExtensionsBaseDirectory()
+    {
+        var overrideDirectory = Environment.GetEnvironmentVariable(ExtensionsBaseDirectoryOverrideEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(overrideDirectory))
+        {
+            return overrideDirectory;
+        }
+
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        return Path.Combine(appData, "SharpIDE", "extensions");
+    }
+
+    public static List<InstalledExtension> Load()
+    {
+        var registryPath = GetRegistryPath();
+        if (!File.Exists(registryPath)) return [];
+
+        try
+        {
+            using var stream = File.OpenRead(registryPath);
+            return JsonSerializer.Deserialize<List<InstalledExtension>>(stream, JsonOptions) ?? [];
+        }
+        catch
+        {
+            // Corrupt registry — start fresh
+            return [];
+        }
+    }
+
+    public static void Save(IReadOnlyList<InstalledExtension> extensions)
+    {
+        var registryPath = GetRegistryPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(registryPath)!);
+
+        using var stream = File.Create(registryPath);
+        JsonSerializer.Serialize(stream, extensions, JsonOptions);
+    }
+}

--- a/src/SharpIDE.Application/Features/LanguageExtensions/LanguageExtensionRegistry.cs
+++ b/src/SharpIDE.Application/Features/LanguageExtensions/LanguageExtensionRegistry.cs
@@ -1,0 +1,104 @@
+namespace SharpIDE.Application.Features.LanguageExtensions;
+
+/// <summary>
+/// Runtime registry mapping file extensions to grammar and language server contributions.
+/// Populated at startup from persisted registry, and updated when extensions are installed/uninstalled.
+/// Thread-safe for reads; writes happen only on install/uninstall (UI thread).
+/// </summary>
+public class LanguageExtensionRegistry
+{
+    // file extension (lowercase, e.g. ".axaml") → grammar contribution
+    private readonly Dictionary<string, GrammarContribution> _grammarsByExtension = new();
+    private readonly Dictionary<string, string> _languageIdsByExtension = new();
+
+    // all installed extensions (for UI listing)
+    private readonly List<InstalledExtension> _extensions = [];
+
+    public IReadOnlyList<InstalledExtension> GetAllExtensions() => _extensions.AsReadOnly();
+
+    /// <summary>
+    /// Returns the grammar for a given file extension (e.g. ".axaml"), or null if none registered.
+    /// </summary>
+    public GrammarContribution? GetGrammar(string fileExtension)
+    {
+        var key = fileExtension.ToLowerInvariant();
+        _grammarsByExtension.TryGetValue(key, out var grammar);
+        return grammar;
+    }
+
+    public string? GetLanguageId(string fileExtension)
+    {
+        _languageIdsByExtension.TryGetValue(fileExtension.ToLowerInvariant(), out var languageId);
+        return languageId;
+    }
+
+    /// <summary>
+    /// Registers an installed extension. If an extension with the same ID already exists, it is replaced.
+    /// If two extensions register the same file extension, the later registration wins.
+    /// </summary>
+    public void Register(InstalledExtension extension)
+    {
+        // Remove any previous registration with the same ID
+        Unregister(extension.Id);
+
+        _extensions.Add(extension);
+
+        // Index grammars by all file extensions declared in LanguageContributions
+        foreach (var lang in extension.Languages)
+        {
+            // Find matching grammar by language ID
+            var grammar = extension.Grammars.FirstOrDefault(g =>
+                string.Equals(g.LanguageId, lang.LanguageId, StringComparison.OrdinalIgnoreCase));
+
+            if (grammar == null) continue;
+
+            foreach (var ext in lang.FileExtensions)
+            {
+                var key = ext.ToLowerInvariant();
+                if (_grammarsByExtension.ContainsKey(key))
+                {
+                    // Later installation wins; log handled by caller
+                }
+                _grammarsByExtension[key] = grammar;
+                _languageIdsByExtension[key] = lang.LanguageId;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Unregisters all contributions of an installed extension by ID.
+    /// </summary>
+    public void Unregister(string extensionId)
+    {
+        var existing = _extensions.FirstOrDefault(e =>
+            string.Equals(e.Id, extensionId, StringComparison.OrdinalIgnoreCase));
+
+        if (existing == null) return;
+
+        _extensions.Remove(existing);
+
+        // Remove grammar mappings contributed by this extension
+        foreach (var lang in existing.Languages)
+        {
+            var grammar = existing.Grammars.FirstOrDefault(g =>
+                string.Equals(g.LanguageId, lang.LanguageId, StringComparison.OrdinalIgnoreCase));
+            if (grammar == null) continue;
+
+            foreach (var ext in lang.FileExtensions)
+            {
+                var key = ext.ToLowerInvariant();
+                if (_grammarsByExtension.TryGetValue(key, out var registered) &&
+                    registered.GrammarFilePath == grammar.GrammarFilePath)
+                {
+                    _grammarsByExtension.Remove(key);
+                }
+
+                if (_languageIdsByExtension.TryGetValue(key, out var registeredLanguageId) &&
+                    string.Equals(registeredLanguageId, lang.LanguageId, StringComparison.OrdinalIgnoreCase))
+                {
+                    _languageIdsByExtension.Remove(key);
+                }
+            }
+        }
+    }
+}

--- a/src/SharpIDE.Application/Features/LanguageExtensions/VsixPackageParser.cs
+++ b/src/SharpIDE.Application/Features/LanguageExtensions/VsixPackageParser.cs
@@ -1,0 +1,504 @@
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace SharpIDE.Application.Features.LanguageExtensions;
+
+/// <summary>
+/// Parses VS Code and VS 2022 for Windows .vsix packages (ZIP archives).
+///
+/// Discovery algorithm:
+///  1. Prefer VS Code manifest assets (`extension/package.json`) when present
+///  2. Otherwise read extension.vsixmanifest (XML) for identity + grammar asset paths
+///  3. Read *.pkgdef for file extension registrations and grammar directory
+///  4. Read LanguageServer/server.json for optional LSP server config
+/// </summary>
+public static partial class VsixPackageParser
+{
+    private const string ManifestEntryName = "extension.vsixmanifest";
+    private const string VsixManifestNamespace = "http://schemas.microsoft.com/developer/vsx-schema/2011";
+    private const string GrammarAssetType = "Microsoft.VisualStudio.TextMate.Grammar";
+    private const string VsCodeManifestAssetType = "Microsoft.VisualStudio.Code.Manifest";
+    private const string LspServerConfigPath = "LanguageServer/server.json";
+    private const string DefaultVsCodeManifestPath = "extension/package.json";
+
+    public static InstalledExtension Parse(string vsixPath)
+    {
+        using var zip = ZipFile.OpenRead(vsixPath);
+        return ParseFromZip(zip);
+    }
+
+    private static InstalledExtension ParseFromZip(ZipArchive zip)
+    {
+        var manifestEntry = zip.GetEntry(ManifestEntryName);
+        var vsCodeManifestPath = FindVsCodeManifestPath(zip, manifestEntry);
+        if (!string.IsNullOrWhiteSpace(vsCodeManifestPath))
+            return ParseVsCodeExtension(zip, vsCodeManifestPath);
+
+        // Step 1: Parse extension.vsixmanifest
+        manifestEntry ??= zip.GetEntry(ManifestEntryName)
+            ?? throw new InvalidOperationException($"'{ManifestEntryName}' not found in .vsix — unsupported extension package");
+
+        using var manifestStream = manifestEntry.Open();
+        var manifest = XDocument.Load(manifestStream);
+        var ns = XNamespace.Get(VsixManifestNamespace);
+
+        var identity = manifest.Descendants(ns + "Identity").FirstOrDefault()
+            ?? throw new InvalidOperationException("No <Identity> element found in vsixmanifest");
+
+        var id = identity.Attribute("Id")?.Value ?? throw new InvalidOperationException("Identity missing Id");
+        var version = identity.Attribute("Version")?.Value ?? "0.0.0";
+        var publisher = identity.Attribute("Publisher")?.Value ?? "Unknown";
+        var displayName = manifest.Descendants(ns + "DisplayName").FirstOrDefault()?.Value ?? id;
+
+        // Step 2: Collect grammar asset paths from manifest
+        var grammarAssetPaths = manifest
+            .Descendants(ns + "Asset")
+            .Where(a => a.Attribute("Type")?.Value == GrammarAssetType)
+            .Select(a => a.Attribute("Path")?.Value)
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Select(p => p!)
+            .ToList();
+
+        // Step 3: Find and parse .pkgdef files
+        var pkgdefEntries = zip.Entries
+            .Where(e => e.Name.EndsWith(".pkgdef", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var fileExtensions = new List<string>();
+        string? grammarDirectory = null;
+
+        foreach (var pkgdefEntry in pkgdefEntries)
+        {
+            using var pkgdefStream = pkgdefEntry.Open();
+            using var reader = new StreamReader(pkgdefStream);
+            var pkgdefContent = reader.ReadToEnd();
+
+            fileExtensions.AddRange(ParseFileExtensionsFromPkgdef(pkgdefContent));
+
+            var dir = ParseGrammarDirectoryFromPkgdef(pkgdefContent);
+            if (dir != null) grammarDirectory = dir;
+        }
+
+        // If .vsixmanifest has grammar assets but no .pkgdef grammar directory,
+        // use the directory of the first grammar asset as the grammar folder
+        if (grammarDirectory == null && grammarAssetPaths.Count > 0)
+        {
+            grammarDirectory = Path.GetDirectoryName(grammarAssetPaths[0])?.Replace('\\', '/');
+        }
+
+        // Extensions like T4Language declare grammars via pkgdef TextMate\Repositories
+        // rather than as explicit manifest Asset elements. In that case scan the grammar
+        // directory inside the ZIP to find the actual .tmLanguage / .tmGrammar files.
+        if (grammarAssetPaths.Count == 0 && grammarDirectory != null)
+        {
+            var prefix = grammarDirectory.TrimEnd('/') + "/";
+            grammarAssetPaths = zip.Entries
+                .Where(e => !e.FullName.EndsWith('/') &&
+                            e.FullName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+                            IsGrammarFile(e.Name))
+                .Select(e => e.FullName)
+                .ToList();
+        }
+
+        // Sort so the grammar whose base name matches a pkgdef-discovered extension comes
+        // first — making it the "primary" grammar (e.g. t4.tmLanguage before csharp.tmLanguage).
+        if (grammarAssetPaths.Count > 1 && fileExtensions.Count > 0)
+        {
+            var extNames = fileExtensions
+                .Select(e => e.TrimStart('.'))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            grammarAssetPaths = grammarAssetPaths
+                .OrderByDescending(p => extNames.Contains(
+                    Path.GetFileNameWithoutExtension(p).Split('.')[0]))
+                .ToList();
+        }
+
+        // Read fileTypes from the primary grammar to fill extensions omitted from pkgdef.
+        // T4Language comments out .tt in ShellFileAssociations because VS owns it natively,
+        // but the grammar plist still lists it in its fileTypes array.
+        if (grammarAssetPaths.Count > 0)
+        {
+            var primaryEntry = zip.GetEntry(grammarAssetPaths[0]);
+            if (primaryEntry != null)
+            {
+                using var grammarStream = primaryEntry.Open();
+                foreach (var ft in ReadFileTypesFromGrammar(grammarStream, grammarAssetPaths[0]))
+                {
+                    var dotExt = ft.StartsWith('.') ? ft.ToLowerInvariant() : "." + ft.ToLowerInvariant();
+                    if (!fileExtensions.Contains(dotExt, StringComparer.OrdinalIgnoreCase))
+                        fileExtensions.Add(dotExt);
+                }
+            }
+        }
+
+        // Build grammar contributions: one per grammar asset path
+        // LanguageId derived from grammar filename (e.g. "fsharp.tmLanguage.json" → "fsharp")
+        var grammars = grammarAssetPaths
+            .Select(path => new GrammarContribution
+            {
+                LanguageId = DeriveLanguageIdFromPath(path),
+                GrammarFilePath = path  // still relative; ExtensionInstaller resolves to absolute
+            })
+            .ToList();
+
+        // Build language contributions: one per discovered file extension
+        // All map to the same language ID (derived from the grammar, or from extension folder name)
+        var languages = fileExtensions
+            .Select(ext => new LanguageContribution
+            {
+                LanguageId = grammars.Count > 0 ? grammars[0].LanguageId : ext.TrimStart('.'),
+                FileExtensions = [ext]
+            })
+            .ToList();
+
+        return new InstalledExtension
+        {
+            Id = id,
+            Version = version,
+            Publisher = publisher,
+            DisplayName = displayName,
+            ExtractedPath = string.Empty,  // set by ExtensionInstaller after extraction
+            PackageKind = ExtensionPackageKind.VisualStudio,
+            Languages = languages,
+            Grammars = grammars
+        };
+    }
+
+    private static InstalledExtension ParseVsCodeExtension(ZipArchive zip, string packageJsonPath)
+    {
+        var packageEntry = zip.GetEntry(packageJsonPath)
+            ?? throw new InvalidOperationException($"VS Code manifest '{packageJsonPath}' not found in .vsix");
+
+        using var packageStream = packageEntry.Open();
+        using var packageDoc = JsonDocument.Parse(packageStream);
+        var root = packageDoc.RootElement;
+
+        var name = root.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : null;
+        if (string.IsNullOrWhiteSpace(name))
+            throw new InvalidOperationException("VS Code extension package.json is missing 'name'");
+
+        var publisher = root.TryGetProperty("publisher", out var publisherEl)
+            ? publisherEl.GetString()
+            : null;
+        publisher = !string.IsNullOrWhiteSpace(publisher)
+            ? publisher
+            : root.TryGetProperty("author", out var authorEl) && authorEl.ValueKind == JsonValueKind.Object &&
+              authorEl.TryGetProperty("name", out var authorNameEl)
+                ? authorNameEl.GetString()
+                : "Unknown";
+
+        var id = !string.IsNullOrWhiteSpace(publisher)
+            ? $"{publisher}.{name}"
+            : name;
+
+        var displayName = root.TryGetProperty("displayName", out var displayNameEl)
+            ? displayNameEl.GetString()
+            : null;
+        var version = root.TryGetProperty("version", out var versionEl)
+            ? versionEl.GetString()
+            : null;
+
+        var packageDirectory = Path.GetDirectoryName(packageJsonPath)?.Replace('\\', '/') ?? string.Empty;
+        var languages = ParseVsCodeLanguages(root, packageDirectory);
+        var grammars = ParseVsCodeGrammars(root, packageDirectory);
+
+        if (languages.Count == 0 && grammars.Count > 0)
+        {
+            languages = grammars
+                .Where(g => !string.IsNullOrWhiteSpace(g.LanguageId))
+                .Select(g => new LanguageContribution
+                {
+                    LanguageId = g.LanguageId,
+                    FileExtensions = ReadFileExtensionsFromZipGrammar(zip, g.GrammarFilePath)
+                        .Select(ft => ft.StartsWith('.') ? ft.ToLowerInvariant() : "." + ft.ToLowerInvariant())
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray()
+                })
+                .Where(l => l.FileExtensions.Length > 0)
+                .ToList();
+        }
+
+        return new InstalledExtension
+        {
+            Id = id!,
+            Version = version ?? "0.0.0",
+            Publisher = publisher ?? "Unknown",
+            DisplayName = displayName ?? name!,
+            ExtractedPath = string.Empty,
+            PackageKind = ExtensionPackageKind.VSCode,
+            Languages = languages,
+            Grammars = grammars
+        };
+    }
+
+    /// <summary>
+    /// Parses file extension registrations from .pkgdef content.
+    /// Handles two pkgdef conventions (stripping ';' comment lines first):
+    ///   [$RootKey$\Languages\File Extensions\.axaml]  — VS language service style
+    ///   [$RootKey$\ShellFileAssociations\.t4]          — T4Language / icon-association style
+    /// </summary>
+    private static IEnumerable<string> ParseFileExtensionsFromPkgdef(string content)
+    {
+        var uncommented = CommentLineRegex().Replace(content, "");
+
+        foreach (Match m in FileExtensionKeyRegex().Matches(uncommented))
+            yield return m.Groups[1].Value.ToLowerInvariant();
+
+        foreach (Match m in ShellFileAssociationsRegex().Matches(uncommented))
+            yield return m.Groups[1].Value.ToLowerInvariant();
+
+        foreach (Match m in EditorExtensionRegex().Matches(uncommented))
+        {
+            var extension = m.Groups[1].Value.ToLowerInvariant();
+            yield return extension.StartsWith('.') ? extension : "." + extension;
+        }
+    }
+
+    /// <summary>
+    /// Parses the TextMate grammar directory from .pkgdef content.
+    /// Looks for: [$RootKey$\TextMate\Repositories] "Name"="$PackageFolder$\Grammars"
+    /// Returns the relative directory path like "Grammars".
+    /// </summary>
+    private static string? ParseGrammarDirectoryFromPkgdef(string content)
+    {
+        var match = TextMateRepositoryRegex().Match(content);
+        if (!match.Success) return null;
+
+        var rawPath = match.Groups[1].Value;
+        // Strip $PackageFolder$\ prefix
+        var normalized = rawPath
+            .Replace("$PackageFolder$\\", "", StringComparison.OrdinalIgnoreCase)
+            .Replace("$PackageFolder$/", "", StringComparison.OrdinalIgnoreCase)
+            .Replace('\\', '/');
+        return normalized;
+    }
+
+    private static string DeriveLanguageIdFromPath(string grammarPath)
+    {
+        var filename = Path.GetFileName(grammarPath);
+        // Strip extensions: "fsharp.tmLanguage.json" → "fsharp"
+        // Strip ".tmLanguage.json" or ".tmLanguage" or ".tmGrammar.json"
+        return TmExtensionRegex().Replace(filename, "").ToLowerInvariant();
+    }
+
+    private static List<LanguageContribution> ParseVsCodeLanguages(JsonElement root, string packageDirectory)
+    {
+        if (!TryGetVsCodeContributes(root, out var contributes) ||
+            !contributes.TryGetProperty("languages", out var languagesEl) ||
+            languagesEl.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var results = new List<LanguageContribution>();
+        foreach (var languageEl in languagesEl.EnumerateArray())
+        {
+            if (!languageEl.TryGetProperty("id", out var idEl))
+                continue;
+
+            var id = idEl.GetString();
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+
+            results.Add(new LanguageContribution
+            {
+                LanguageId = id!,
+                FileExtensions = ReadStringArray(languageEl, "extensions")
+                    .Select(NormalizeFileExtension)
+                    .Where(static e => !string.IsNullOrWhiteSpace(e))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                FileNames = ReadStringArray(languageEl, "filenames")
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                FirstLinePattern = languageEl.TryGetProperty("firstLine", out var firstLineEl)
+                    ? firstLineEl.GetString()
+                    : null
+            });
+        }
+
+        return results;
+    }
+
+    private static List<GrammarContribution> ParseVsCodeGrammars(JsonElement root, string packageDirectory)
+    {
+        if (!TryGetVsCodeContributes(root, out var contributes) ||
+            !contributes.TryGetProperty("grammars", out var grammarsEl) ||
+            grammarsEl.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var results = new List<GrammarContribution>();
+        foreach (var grammarEl in grammarsEl.EnumerateArray())
+        {
+            if (!grammarEl.TryGetProperty("path", out var pathEl))
+                continue;
+
+            var relativePath = pathEl.GetString();
+            if (string.IsNullOrWhiteSpace(relativePath))
+                continue;
+
+            var languageId = grammarEl.TryGetProperty("language", out var languageEl)
+                ? languageEl.GetString()
+                : null;
+            var scopeName = grammarEl.TryGetProperty("scopeName", out var scopeEl)
+                ? scopeEl.GetString()
+                : null;
+
+            results.Add(new GrammarContribution
+            {
+                LanguageId = !string.IsNullOrWhiteSpace(languageId)
+                    ? languageId!
+                    : DeriveLanguageIdFromPath(relativePath!),
+                ScopeName = scopeName ?? string.Empty,
+                GrammarFilePath = CombineZipPath(packageDirectory, relativePath!)
+            });
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Reads the fileTypes array from a TextMate grammar file (plist XML or JSON).
+    /// Returns bare extension strings without dots, e.g. "tt", "t4", "ttinclude".
+    /// </summary>
+    private static IEnumerable<string> ReadFileTypesFromGrammar(Stream stream, string path)
+    {
+        IEnumerable<string> result;
+        try
+        {
+            if (path.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            {
+                using var doc = JsonDocument.Parse(stream);
+                if (!doc.RootElement.TryGetProperty("fileTypes", out var ft) ||
+                    ft.ValueKind != JsonValueKind.Array)
+                    yield break;
+                result = ft.EnumerateArray()
+                    .Select(e => e.GetString())
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .Select(s => s!)
+                    .ToArray();
+            }
+            else // plist XML (.tmLanguage / .tmGrammar)
+            {
+                var xml = XDocument.Load(stream);
+                var fileTypesKey = xml.Descendants("key")
+                    .FirstOrDefault(k => k.Value == "fileTypes");
+                if (fileTypesKey?.NextNode is not XElement { Name.LocalName: "array" } array)
+                    yield break;
+                result = array.Elements("string").Select(e => e.Value).ToArray();
+            }
+        }
+        catch
+        {
+            yield break; // malformed grammar — skip silently
+        }
+
+        foreach (var ft in result)
+            yield return ft;
+    }
+
+    private static bool IsGrammarFile(string filename) =>
+        filename.EndsWith(".tmLanguage", StringComparison.OrdinalIgnoreCase) ||
+        filename.EndsWith(".tmLanguage.json", StringComparison.OrdinalIgnoreCase) ||
+        filename.EndsWith(".tmGrammar", StringComparison.OrdinalIgnoreCase) ||
+        filename.EndsWith(".tmGrammar.json", StringComparison.OrdinalIgnoreCase);
+
+    private static string? FindVsCodeManifestPath(ZipArchive zip, ZipArchiveEntry? manifestEntry)
+    {
+        if (manifestEntry != null)
+        {
+            using var manifestStream = manifestEntry.Open();
+            var manifest = XDocument.Load(manifestStream);
+            var ns = XNamespace.Get(VsixManifestNamespace);
+            var path = manifest
+                .Descendants(ns + "Asset")
+                .FirstOrDefault(a => a.Attribute("Type")?.Value == VsCodeManifestAssetType)
+                ?.Attribute("Path")?.Value;
+            if (!string.IsNullOrWhiteSpace(path))
+                return path!.Replace('\\', '/');
+        }
+
+        if (zip.GetEntry(DefaultVsCodeManifestPath) != null)
+            return DefaultVsCodeManifestPath;
+
+        return zip.Entries
+            .Where(e => !e.FullName.EndsWith('/'))
+            .Select(e => e.FullName.Replace('\\', '/'))
+            .FirstOrDefault(p => p.EndsWith("/package.json", StringComparison.OrdinalIgnoreCase) &&
+                                 p.StartsWith("extension/", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool TryGetVsCodeContributes(JsonElement root, out JsonElement contributes)
+    {
+        if (root.TryGetProperty("contributes", out contributes) &&
+            contributes.ValueKind == JsonValueKind.Object)
+            return true;
+
+        contributes = default;
+        return false;
+    }
+
+    private static IEnumerable<string> ReadStringArray(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var arrayEl) || arrayEl.ValueKind != JsonValueKind.Array)
+            yield break;
+
+        foreach (var item in arrayEl.EnumerateArray())
+        {
+            var value = item.GetString();
+            if (!string.IsNullOrWhiteSpace(value))
+                yield return value!;
+        }
+    }
+
+    private static string NormalizeFileExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            return string.Empty;
+
+        return extension.StartsWith(".", StringComparison.Ordinal)
+            ? extension.ToLowerInvariant()
+            : "." + extension.ToLowerInvariant();
+    }
+
+    private static string CombineZipPath(string baseDirectory, string relativePath)
+    {
+        var normalizedRelative = relativePath.Replace('\\', '/');
+        if (normalizedRelative.StartsWith("./", StringComparison.Ordinal))
+            normalizedRelative = normalizedRelative[2..];
+
+        if (string.IsNullOrWhiteSpace(baseDirectory))
+            return normalizedRelative;
+
+        return $"{baseDirectory.TrimEnd('/')}/{normalizedRelative}".TrimStart('/');
+    }
+
+    private static IEnumerable<string> ReadFileExtensionsFromZipGrammar(ZipArchive zip, string grammarPath)
+    {
+        var entry = zip.GetEntry(grammarPath);
+        if (entry == null)
+            yield break;
+
+        using var stream = entry.Open();
+        foreach (var ft in ReadFileTypesFromGrammar(stream, grammarPath))
+            yield return ft;
+    }
+
+    [GeneratedRegex(@"^;.*$", RegexOptions.Multiline)]
+    private static partial Regex CommentLineRegex();
+
+    [GeneratedRegex(@"\[\$RootKey\$\\Languages\\File Extensions\\(\.[a-zA-Z0-9_]+)\]", RegexOptions.IgnoreCase)]
+    private static partial Regex FileExtensionKeyRegex();
+
+    [GeneratedRegex(@"\[\$RootKey\$\\ShellFileAssociations\\(\.[a-zA-Z0-9_]+)\]", RegexOptions.IgnoreCase)]
+    private static partial Regex ShellFileAssociationsRegex();
+
+    [GeneratedRegex(@"\[\$RootKey\$\\Editors\\\{[^}]+\}\\Extensions\][^\[]*^\s*""([^""\\/\r\n]+)""\s*=\s*dword:", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline)]
+    private static partial Regex EditorExtensionRegex();
+
+    [GeneratedRegex(@"\[\$RootKey\$\\TextMate\\Repositories\][^\[]*""[^""]*""\s*=\s*""([^""]+)""", RegexOptions.Singleline | RegexOptions.IgnoreCase)]
+    private static partial Regex TextMateRepositoryRegex();
+
+    [GeneratedRegex(@"\.(tmLanguage|tmGrammar)(\.json)?$", RegexOptions.IgnoreCase)]
+    private static partial Regex TmExtensionRegex();
+}

--- a/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit.cs
@@ -15,10 +15,12 @@ using SharpIDE.Application.Features.Editor;
 using SharpIDE.Application.Features.Events;
 using SharpIDE.Application.Features.FilePersistence;
 using SharpIDE.Application.Features.FileWatching;
+using SharpIDE.Application.Features.LanguageExtensions;
 using SharpIDE.Application.Features.NavigationHistory;
 using SharpIDE.Application.Features.Run;
 using SharpIDE.Application.Features.SolutionDiscovery;
 using SharpIDE.Application.Features.SolutionDiscovery.VsPersistence;
+using SharpIDE.Godot.Features.CodeEditor.TextMate;
 using Task = System.Threading.Tasks.Task;
 
 namespace SharpIDE.Godot.Features.CodeEditor;
@@ -34,6 +36,9 @@ public partial class SharpIdeCodeEdit : CodeEdit
 	private SharpIdeFile _currentFile = null!;
 	
 	private CustomHighlighter _syntaxHighlighter = new();
+	private GrammarSyntaxHighlighter? _grammarSyntaxHighlighter;
+	private GrammarContribution? _activeGrammarContribution;
+	private bool _usingGrammarHighlighter;
 	private PopupMenu _popupMenu = null!;
 	private CanvasItem _aboveCanvasItem = null!;
 	private Rid? _aboveCanvasItemRid = null!;
@@ -63,6 +68,7 @@ public partial class SharpIdeCodeEdit : CodeEdit
     [Inject] private readonly IdeNavigationHistoryService _navigationHistoryService = null!;
     [Inject] private readonly EditorCaretPositionService _editorCaretPositionService = null!;
     [Inject] private readonly SharpIdeMetadataAsSourceService _sharpIdeMetadataAsSourceService = null!;
+    [Inject] private readonly LanguageExtensionRegistry _languageExtensionRegistry = null!;
 
 	public SharpIdeCodeEdit()
 	{
@@ -241,6 +247,11 @@ public partial class SharpIdeCodeEdit : CodeEdit
 	{
 		_findReplaceBar.NeedsToCountResults = true;
 		var text = Text;
+		if (_usingGrammarHighlighter)
+		{
+			Callable.From(() => RecolorizeWithGrammar(Text)).CallDeferred();
+		}
+
 		var pendingCompletionTrigger = _pendingCompletionTrigger;
 		_pendingCompletionTrigger = null;
 		var cursorPosition = GetCaretPosition();
@@ -299,6 +310,10 @@ public partial class SharpIdeCodeEdit : CodeEdit
 			SetCaretColumn(currentCaretPosition.col);
 			SetVScroll(vScroll);
 			EndComplexOperation();
+			if (_usingGrammarHighlighter)
+			{
+				RecolorizeWithGrammar(fileContents);
+			}
 		});
 	}
 
@@ -325,6 +340,20 @@ public partial class SharpIdeCodeEdit : CodeEdit
 	{
 		await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding); // get off the UI thread
 		using var __ = SharpIdeOtel.Source.StartActivity($"{nameof(SharpIdeCodeEdit)}.{nameof(SetSharpIdeFile)}");
+		var grammarContribution = _languageExtensionRegistry.GetGrammar(Path.GetExtension(file.Path));
+		_activeGrammarContribution = grammarContribution;
+		_usingGrammarHighlighter = grammarContribution != null;
+		if (grammarContribution != null)
+		{
+			var grammarHighlighter = new GrammarSyntaxHighlighter();
+			grammarHighlighter.LoadGrammar(grammarContribution);
+			_grammarSyntaxHighlighter = grammarHighlighter;
+		}
+		else
+		{
+			_grammarSyntaxHighlighter = null;
+		}
+
 		_currentFile = file;
 		var readFileTask = _openTabsFileManager.GetFileTextAsync(file);
 		_currentFile.FileContentsChangedExternally.Subscribe(OnFileChangedExternally);
@@ -347,11 +376,16 @@ public partial class SharpIdeCodeEdit : CodeEdit
 		var setTextTask = this.InvokeAsync(async () =>
 		{
 			_fileChangingSuppressBreakpointToggleEvent = true;
-			SetText(await readFileTask);
+			var text = await readFileTask;
+			SetText(text);
 			_fileChangingSuppressBreakpointToggleEvent = false;
 			ClearUndoHistory();
 			if (fileLinePosition is not null) SetFileLinePosition(fileLinePosition.Value);
 			if (file.IsMetadataAsSourceFile) Editable = false;
+			if (_usingGrammarHighlighter)
+			{
+				RecolorizeWithGrammar(text);
+			}
 		});
 		_ = Task.GodotRun(async () =>
 		{
@@ -600,11 +634,35 @@ public partial class SharpIdeCodeEdit : CodeEdit
 	[RequiresGodotUiThread]
 	private void SetSyntaxHighlightingModel(ImmutableArray<SharpIdeClassifiedSpan> classifiedSpans, ImmutableArray<SharpIdeRazorClassifiedSpan> razorClassifiedSpans)
 	{
+		if (_usingGrammarHighlighter && classifiedSpans.IsEmpty && razorClassifiedSpans.IsEmpty)
+		{
+			RecolorizeWithGrammar(Text);
+			return;
+		}
+
+		if (_usingGrammarHighlighter && (!classifiedSpans.IsEmpty || !razorClassifiedSpans.IsEmpty))
+		{
+			_usingGrammarHighlighter = false;
+		}
+
 		_syntaxHighlighter.SetHighlightingData(classifiedSpans, razorClassifiedSpans);
 		//_syntaxHighlighter.ClearHighlightingCache();
 		_syntaxHighlighter.UpdateCache(); // I don't think this does anything, it will call _UpdateCache which we have not implemented
 		SyntaxHighlighter = null;
 		SyntaxHighlighter = _syntaxHighlighter; // Reassign to trigger redraw
+	}
+
+	[RequiresGodotUiThread]
+	internal void RecolorizeWithGrammar(string text)
+	{
+		if (_grammarSyntaxHighlighter == null || !_grammarSyntaxHighlighter.IsGrammarLoaded)
+		{
+			return;
+		}
+
+		_grammarSyntaxHighlighter.Colorize(text, _syntaxHighlighter.ColourSetForTheme);
+		SyntaxHighlighter = null;
+		SyntaxHighlighter = _grammarSyntaxHighlighter;
 	}
 
 	private void OnCodeFixesRequested()

--- a/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit_Theme.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/SharpIdeCodeEdit_Theme.cs
@@ -23,6 +23,12 @@ public partial class SharpIdeCodeEdit
     private void UpdateEditorTheme(LightOrDarkTheme lightOrDarkTheme)
     {
         _syntaxHighlighter.UpdateThemeColorCache(lightOrDarkTheme);
+        if (_usingGrammarHighlighter)
+        {
+            RecolorizeWithGrammar(Text);
+            return;
+        }
+
         SyntaxHighlighter = null;
         SyntaxHighlighter = _syntaxHighlighter; // Reassign to trigger redraw
     }

--- a/src/SharpIDE.Godot/Features/CodeEditor/TextMate/GrammarSyntaxHighlighter.cs
+++ b/src/SharpIDE.Godot/Features/CodeEditor/TextMate/GrammarSyntaxHighlighter.cs
@@ -1,0 +1,521 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Xml.Linq;
+using Godot;
+using Godot.Collections;
+using SharpIDE.Application.Features.LanguageExtensions;
+using TextMateSharp.Grammars;
+using TextMateSharp.Internal.Grammars.Reader;
+using TextMateSharp.Internal.Types;
+using TextMateSharp.Registry;
+using TextMateSharp.Themes;
+
+namespace SharpIDE.Godot.Features.CodeEditor.TextMate;
+
+/// <summary>
+/// Godot SyntaxHighlighter that tokenizes source text using a TextMate grammar loaded from a
+/// Visual Studio or VS Code extension and maps scopes onto the IDE's built-in editor palette.
+/// </summary>
+public partial class GrammarSyntaxHighlighter : SyntaxHighlighter
+{
+    private const string TextMateTraceEnabledEnvironmentVariable = "SHARPIDE_TEXTMATE_TRACE";
+    private const string TextMateTraceFileEnvironmentVariable = "SHARPIDE_TEXTMATE_TRACE_FILE";
+    private static readonly StringName ColorStringName = "color";
+    private readonly Dictionary _emptyDict = new();
+
+    private IGrammar? _grammar;
+    private string _primaryScopeName = "source.unknown";
+    private List<CandidateGrammar> _candidateEmbeddedGrammars = [];
+    private EditorThemeColorSet _fallbackColorSet = EditorThemeColours.Dark;
+
+    // Pre-computed per-line highlights: line index → (column → Color)
+    private readonly System.Collections.Generic.Dictionary<int,
+        System.Collections.Generic.Dictionary<int, Color>> _lineHighlights = new();
+
+    public bool IsGrammarLoaded => _grammar != null;
+
+    /// <summary>
+    /// Loads the TextMate grammar from the contribution's file path.
+    /// Sets <see cref="IsGrammarLoaded"/> to true on success.
+    /// </summary>
+    public void LoadGrammar(GrammarContribution grammarContribution)
+    {
+        Trace($"LoadGrammar path='{grammarContribution.GrammarFilePath}' scopeHint='{grammarContribution.ScopeName}' fileExists={File.Exists(grammarContribution.GrammarFilePath)}");
+        try
+        {
+            var options = new SingleFileRegistryOptions(grammarContribution.GrammarFilePath, grammarContribution.ScopeName);
+            Trace($"  resolvedScope='{options.ResolvedScopeName}'");
+            var registry = new Registry(options);
+            _primaryScopeName = options.ResolvedScopeName;
+            _grammar = registry.LoadGrammar(options.ResolvedScopeName);
+
+            if (_grammar == null)
+            {
+                Trace($"  ERROR: Grammar loaded as null for scope '{options.ResolvedScopeName}'");
+                GD.PrintErr($"[GrammarSyntaxHighlighter] Grammar loaded as null for scope '{options.ResolvedScopeName}'");
+            }
+            else
+            {
+                Trace("  OK: grammar loaded");
+                _candidateEmbeddedGrammars = options.GetSiblingScopeNames()
+                    .Where(scopeName => !string.Equals(scopeName, _primaryScopeName, StringComparison.OrdinalIgnoreCase))
+                    .Select(scopeName => new CandidateGrammar(scopeName, registry.LoadGrammar(scopeName)))
+                    .Where(candidate => candidate.Grammar != null)
+                    .ToList()!;
+                Trace($"  loaded {_candidateEmbeddedGrammars.Count} sibling grammar candidate(s)");
+            }
+        }
+        catch (Exception ex)
+        {
+            Trace($"  EXCEPTION: {ex.GetType().Name}: {ex.Message}");
+            GD.PrintErr($"[GrammarSyntaxHighlighter] Failed to load grammar from '{grammarContribution.GrammarFilePath}': {ex.Message}");
+            _grammar = null;
+        }
+    }
+
+    /// <summary>
+    /// Tokenizes all lines of the document and caches per-line color data.
+    /// Call this whenever the document text changes.
+    /// </summary>
+    public void Colorize(string fullText, EditorThemeColorSet fallback)
+    {
+        _fallbackColorSet = fallback;
+        _lineHighlights.Clear();
+
+        if (_grammar == null) { Trace("Colorize: grammar is null, skipping"); return; }
+        Trace($"Colorize: tokenizing {fullText.Split('\n').Length} lines");
+
+        var lines = fullText.Split('\n');
+        IStateStack? stateStack = null;
+        var candidateStateStacks = _candidateEmbeddedGrammars.ToDictionary(
+            candidate => candidate.ScopeName,
+            _ => (IStateStack?)null,
+            StringComparer.OrdinalIgnoreCase);
+        var totalColoredLines = 0;
+
+        for (int lineIdx = 0; lineIdx < lines.Length; lineIdx++)
+        {
+            var lineText = lines[lineIdx];
+            // Strip \r for Windows CRLF
+            if (lineText.Length > 0 && lineText[^1] == '\r')
+                lineText = lineText[..^1];
+
+            try
+            {
+                var result = _grammar.TokenizeLine(lineText, stateStack, TimeSpan.MaxValue);
+                stateStack = result.RuleStack;
+
+                var bestTokens = result.Tokens;
+                var bestScore = ScoreTokens(result.Tokens, _primaryScopeName);
+
+                if (ShouldTrySiblingGrammarFallback(lineText, bestScore))
+                {
+                    foreach (var candidate in _candidateEmbeddedGrammars)
+                    {
+                        var candidateResult = candidate.Grammar!.TokenizeLine(lineText, candidateStateStacks[candidate.ScopeName], TimeSpan.MaxValue);
+                        candidateStateStacks[candidate.ScopeName] = candidateResult.RuleStack;
+
+                        var candidateScore = ScoreTokens(candidateResult.Tokens, candidate.ScopeName);
+                        if (candidateScore > bestScore)
+                        {
+                            bestTokens = candidateResult.Tokens;
+                            bestScore = candidateScore;
+                        }
+                    }
+                }
+
+                var lineDict = new System.Collections.Generic.Dictionary<int, Color>();
+                foreach (var token in bestTokens)
+                {
+                    var color = ResolveTokenColor(token.Scopes);
+                    if (color.HasValue)
+                        lineDict[token.StartIndex] = color.Value;
+                }
+
+                if (lineDict.Count > 0)
+                {
+                    _lineHighlights[lineIdx] = lineDict;
+                    totalColoredLines++;
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace($"  tokenize exception line {lineIdx}: {ex.GetType().Name}: {ex.Message}");
+                // Leave line un-colored on tokenization failure; keep stateStack as-is
+            }
+        }
+        Trace($"  Colorize done: {totalColoredLines}/{lines.Length} lines have color data");
+    }
+
+    private static bool ShouldTrySiblingGrammarFallback(string lineText, int primaryScore)
+    {
+        return primaryScore == 0 && string.IsNullOrWhiteSpace(lineText) is false;
+    }
+
+    private static int ScoreTokens(IEnumerable<IToken> tokens, string rootScopeName)
+    {
+        var score = 0;
+        foreach (var token in tokens)
+        {
+            foreach (var scope in token.Scopes)
+            {
+                if (string.Equals(scope, rootScopeName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (scope.StartsWith("source.", StringComparison.OrdinalIgnoreCase) ||
+                    scope.StartsWith("text.", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                score++;
+            }
+        }
+
+        return score;
+    }
+
+    private static void Trace(string message)
+    {
+        if (IsTraceEnabled() is false)
+        {
+            return;
+        }
+
+        var line = $"[TextMate] {message}";
+        GD.Print(line);
+
+        var traceFilePath = System.Environment.GetEnvironmentVariable(TextMateTraceFileEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(traceFilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            File.AppendAllText(traceFilePath, $"[{DateTime.Now:HH:mm:ss.fff}] {line}{System.Environment.NewLine}");
+        }
+        catch
+        {
+            // Best-effort file logging only.
+        }
+    }
+
+    private static bool IsTraceEnabled()
+    {
+        var value = System.Environment.GetEnvironmentVariable(TextMateTraceEnabledEnvironmentVariable);
+        return string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(value, "on", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override Dictionary _GetLineSyntaxHighlighting(int line)
+    {
+        if (!_lineHighlights.TryGetValue(line, out var lineColors))
+            return _emptyDict;
+
+        var result = new Dictionary();
+        foreach (var (col, color) in lineColors)
+        {
+            result[col] = new Dictionary { { ColorStringName, color } };
+        }
+        return result;
+    }
+
+    // -------------------------------------------------------------------------
+    // Color resolution
+    // -------------------------------------------------------------------------
+
+    private Color? ResolveTokenColor(IEnumerable<string> scopes)
+    {
+        return DefaultScopeColorMapper.GetColor(scopes, _fallbackColorSet);
+    }
+
+    // -------------------------------------------------------------------------
+    // Built-in scope → color fallback (no TextMate theme required)
+    // -------------------------------------------------------------------------
+
+    private static class DefaultScopeColorMapper
+    {
+        /// <summary>
+        /// Maps common TextMate scopes to EditorThemeColorSet colors.
+        /// Checks from innermost (most-specific) to outermost scope.
+        /// </summary>
+        public static Color? GetColor(IEnumerable<string> scopes, EditorThemeColorSet colorSet)
+        {
+            // scopes is ordered outermost→innermost; iterate innermost-first
+            foreach (var scope in scopes.Reverse())
+            {
+                var color = MapScope(scope, colorSet);
+                if (color.HasValue) return color;
+            }
+            return null;
+        }
+
+        private static Color? MapScope(string scope, EditorThemeColorSet cs)
+        {
+            if (scope.StartsWith("comment", StringComparison.Ordinal))               return cs.CommentGreen;
+            if (scope.StartsWith("string", StringComparison.Ordinal))                return cs.LightOrangeBrown;
+            if (scope.StartsWith("constant.numeric", StringComparison.Ordinal))      return cs.NumberGreen;
+            if (scope.StartsWith("constant.character.escape", StringComparison.Ordinal)) return cs.Yellow;
+            if (scope.StartsWith("constant.language", StringComparison.Ordinal))     return cs.KeywordBlue;
+            if (scope.StartsWith("keyword.operator", StringComparison.Ordinal))      return cs.White;
+            if (scope.StartsWith("keyword", StringComparison.Ordinal))               return cs.KeywordBlue;
+            if (scope.StartsWith("storage", StringComparison.Ordinal))               return cs.KeywordBlue;
+            if (scope.StartsWith("entity.other.attribute-name", StringComparison.Ordinal)) return cs.InterfaceGreen;
+            if (scope.StartsWith("entity.name.type.interface", StringComparison.Ordinal)) return cs.InterfaceGreen;
+            if (scope.StartsWith("entity.name.type", StringComparison.Ordinal))      return cs.ClassGreen;
+            if (scope.StartsWith("entity.name.function", StringComparison.Ordinal))  return cs.Yellow;
+            if (scope.StartsWith("entity.name.namespace", StringComparison.Ordinal)) return cs.White;
+            if (scope.StartsWith("entity.name", StringComparison.Ordinal))           return cs.ClassGreen;
+            if (scope.StartsWith("support.type", StringComparison.Ordinal))          return cs.ClassGreen;
+            if (scope.StartsWith("support.function", StringComparison.Ordinal))      return cs.Yellow;
+            if (scope.StartsWith("variable.parameter", StringComparison.Ordinal))    return cs.Gray;
+            if (scope.StartsWith("variable.other.constant", StringComparison.Ordinal)) return cs.VariableBlue;
+            if (scope.StartsWith("variable", StringComparison.Ordinal))              return cs.VariableBlue;
+            if (scope.StartsWith("invalid", StringComparison.Ordinal))               return cs.ErrorRed;
+            if (scope.StartsWith("markup.heading", StringComparison.Ordinal))        return cs.KeywordBlue;
+            if (scope.StartsWith("markup.bold", StringComparison.Ordinal))           return cs.Yellow;
+            if (scope.StartsWith("markup.italic", StringComparison.Ordinal))         return cs.Orange;
+            if (scope.StartsWith("punctuation.section.embedded", StringComparison.Ordinal)) return cs.HtmlDelimiterGray;
+            if (scope.StartsWith("punctuation.separator.key-value", StringComparison.Ordinal)) return cs.White;
+            if (scope.StartsWith("punctuation.definition.tag", StringComparison.Ordinal)) return cs.HtmlDelimiterGray;
+            if (scope.StartsWith("punctuation.definition.string", StringComparison.Ordinal)) return cs.LightOrangeBrown;
+            if (scope.StartsWith("meta.tag", StringComparison.Ordinal))              return cs.KeywordBlue;
+            return null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // IRegistryOptions implementation for a single grammar file
+    // -------------------------------------------------------------------------
+
+    private sealed class SingleFileRegistryOptions : IRegistryOptions
+    {
+        private readonly string _grammarFilePath;
+
+        /// <summary>The scope name resolved from the grammar file or the provided hint.</summary>
+        public string ResolvedScopeName { get; }
+
+        public SingleFileRegistryOptions(string grammarFilePath, string? hintScopeName)
+        {
+            _grammarFilePath = grammarFilePath;
+            ResolvedScopeName = !string.IsNullOrWhiteSpace(hintScopeName)
+                ? hintScopeName
+                : ReadScopeNameFromFile(grammarFilePath) ?? "source.unknown";
+        }
+
+        public IReadOnlyList<string> GetSiblingScopeNames()
+        {
+            var directory = Path.GetDirectoryName(_grammarFilePath);
+            if (directory == null)
+            {
+                return [];
+            }
+
+            return Directory.EnumerateFiles(directory)
+                .Where(IsTmGrammarFile)
+                .Select(ReadScopeNameFromFile)
+                .Where(scopeName => !string.IsNullOrWhiteSpace(scopeName))
+                .Cast<string>()
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(scopeName => scopeName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        public IRawGrammar GetGrammar(string scopeName)
+        {
+            // Primary grammar
+            if (string.Equals(scopeName, ResolvedScopeName, StringComparison.OrdinalIgnoreCase))
+                return ReadGrammarFile(_grammarFilePath);
+
+            // Look for a sibling grammar in the same directory that declares this scope name.
+            // This resolves embedded grammars such as source.cs inside T4 templates, where
+            // the extension ships csharp.tmLanguage alongside t4.tmLanguage in Syntaxes/.
+            var directory = Path.GetDirectoryName(_grammarFilePath);
+            if (directory != null)
+            {
+                foreach (var candidate in Directory.EnumerateFiles(directory).Where(IsTmGrammarFile))
+                {
+                    var candidateScope = ReadScopeNameFromFile(candidate);
+                    if (string.Equals(candidateScope, scopeName, StringComparison.OrdinalIgnoreCase))
+                        return ReadGrammarFile(candidate);
+                }
+            }
+
+            return null!;
+        }
+
+        private static IRawGrammar ReadGrammarFile(string filePath)
+        {
+            try
+            {
+                // TextMateSharp's GrammarReader only supports JSON-format grammars.
+                // XML PList (.tmLanguage/.tmGrammar without .json) must be converted first.
+                var isXmlPlist = !filePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase);
+                var json = isXmlPlist
+                    ? ConvertPlistXmlToJson(filePath)
+                    : File.ReadAllText(filePath, System.Text.Encoding.UTF8);
+
+                using var reader = new StreamReader(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json)));
+                return GrammarReader.ReadGrammarSync(reader);
+            }
+            catch (Exception ex)
+            {
+                GD.PrintErr($"[SingleFileRegistryOptions] Failed to read grammar '{filePath}': {ex.Message}");
+                return null!;
+            }
+        }
+
+        /// <summary>
+        /// Converts a TextMate XML PList grammar file to JSON string that TextMateSharp can parse.
+        /// PList types map to JSON: dict→object, array→array, string→string, integer→number,
+        /// real→number, true→true, false→false.
+        /// </summary>
+        private static string ConvertPlistXmlToJson(string filePath)
+        {
+            var doc = XDocument.Load(filePath);
+            // Root is <plist><dict>...</dict></plist>
+            var root = doc.Descendants("dict").FirstOrDefault()
+                ?? throw new InvalidOperationException("No root <dict> found in PList grammar");
+
+            var sb = new System.Text.StringBuilder();
+            WritePlistNode(root, sb);
+            return sb.ToString();
+        }
+
+        private static void WritePlistNode(XElement element, System.Text.StringBuilder sb)
+        {
+            switch (element.Name.LocalName)
+            {
+                case "dict":
+                    sb.Append('{');
+                    var dictChildren = element.Elements().ToList();
+                    var first = true;
+                    for (int i = 0; i + 1 < dictChildren.Count; i += 2)
+                    {
+                        var keyEl = dictChildren[i];
+                        var valEl = dictChildren[i + 1];
+                        if (keyEl.Name.LocalName != "key") continue;
+                        if (!first) sb.Append(',');
+                        first = false;
+                        sb.Append(System.Text.Json.JsonSerializer.Serialize(keyEl.Value));
+                        sb.Append(':');
+                        WritePlistNode(valEl, sb);
+                    }
+                    sb.Append('}');
+                    break;
+
+                case "array":
+                    sb.Append('[');
+                    var arrFirst = true;
+                    foreach (var child in element.Elements())
+                    {
+                        if (!arrFirst) sb.Append(',');
+                        arrFirst = false;
+                        WritePlistNode(child, sb);
+                    }
+                    sb.Append(']');
+                    break;
+
+                case "string":
+                    sb.Append(System.Text.Json.JsonSerializer.Serialize(element.Value));
+                    break;
+
+                case "integer":
+                    sb.Append(long.TryParse(element.Value, out var lval) ? lval.ToString() : "0");
+                    break;
+
+                case "real":
+                    sb.Append(double.TryParse(element.Value, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out var dval)
+                        ? dval.ToString(System.Globalization.CultureInfo.InvariantCulture) : "0");
+                    break;
+
+                case "true":
+                    sb.Append("true");
+                    break;
+
+                case "false":
+                    sb.Append("false");
+                    break;
+
+                default:
+                    sb.Append("null");
+                    break;
+            }
+        }
+
+        private static bool IsTmGrammarFile(string path) =>
+            path.EndsWith(".tmLanguage", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".tmGrammar", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".tmLanguage.json", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".tmGrammar.json", StringComparison.OrdinalIgnoreCase);
+
+        public ICollection<string> GetInjections(string scopeName) => null!;
+
+        public IRawTheme GetTheme(string scopeName) => EmptyRawTheme.Instance;
+
+        public IRawTheme GetDefaultTheme() => EmptyRawTheme.Instance;
+
+        /// <summary>
+        /// Minimal IRawTheme that satisfies TextMateSharp's Registry constructor.
+        /// We do our own color resolution so we don't need theme-based coloring from TextMateSharp.
+        /// </summary>
+        private sealed class EmptyRawTheme : IRawTheme
+        {
+            public static readonly EmptyRawTheme Instance = new();
+            public string GetName() => string.Empty;
+            public ICollection<IRawThemeSetting> GetSettings() => [];
+            public ICollection<IRawThemeSetting> GetTokenColors() => [];
+            public ICollection<KeyValuePair<string, object>> GetGuiColors() => [];
+            public string? GetInclude() => null;
+        }
+
+        // ---------------------------------------------------------------
+        // Scope name extraction from grammar file
+        // ---------------------------------------------------------------
+
+        private static string? ReadScopeNameFromFile(string filePath)
+        {
+            try
+            {
+                var ext = Path.GetExtension(filePath);
+                if (ext.Equals(".json", StringComparison.OrdinalIgnoreCase))
+                    return ReadScopeNameFromJson(filePath);
+
+                // plist XML (.tmLanguage / .tmGrammar)
+                return ReadScopeNameFromPlist(filePath);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string? ReadScopeNameFromJson(string filePath)
+        {
+            using var stream = File.OpenRead(filePath);
+            using var doc = JsonDocument.Parse(stream);
+            return doc.RootElement.TryGetProperty("scopeName", out var el) ? el.GetString() : null;
+        }
+
+        private static string? ReadScopeNameFromPlist(string filePath)
+        {
+            var xdoc = XDocument.Load(filePath);
+            var keys = xdoc.Descendants("key");
+            foreach (var key in keys)
+            {
+                if (key.Value != "scopeName") continue;
+                if (key.NextNode is XElement nextEl)
+                    return nextEl.Value;
+            }
+            return null;
+        }
+    }
+
+    private sealed record CandidateGrammar(string ScopeName, IGrammar? Grammar);
+}

--- a/src/SharpIDE.Godot/Features/ExtensionManager/ExtensionManagerWindow.cs
+++ b/src/SharpIDE.Godot/Features/ExtensionManager/ExtensionManagerWindow.cs
@@ -1,0 +1,168 @@
+using Godot;
+using Microsoft.Extensions.Logging;
+using SharpIDE.Application.Features.LanguageExtensions;
+
+namespace SharpIDE.Godot.Features.ExtensionManager;
+
+/// <summary>
+/// Popup window for installing and uninstalling VS Code and Visual Studio language extensions (.vsix).
+/// Uses programmatic UI — no .tscn required.
+/// </summary>
+public partial class ExtensionManagerWindow : Window
+{
+    [Inject] private readonly ExtensionInstaller _extensionInstaller = null!;
+    [Inject] private readonly LanguageExtensionRegistry _languageExtensionRegistry = null!;
+    [Inject] private readonly ILogger<ExtensionManagerWindow> _logger = null!;
+
+    private ItemList _extensionList = null!;
+    private Button _installButton = null!;
+    private Button _uninstallButton = null!;
+    private Label _statusLabel = null!;
+    private FileDialog _vsixFileDialog = null!;
+
+    public override void _Ready()
+    {
+        Title = "Language Extensions";
+        MinSize = new Vector2I(520, 360);
+        CloseRequested += Hide;
+
+        BuildUi();
+        PopulateList();
+    }
+
+    private void BuildUi()
+    {
+        var margin = new MarginContainer();
+        margin.AddThemeConstantOverride("margin_top", 8);
+        margin.AddThemeConstantOverride("margin_bottom", 8);
+        margin.AddThemeConstantOverride("margin_left", 8);
+        margin.AddThemeConstantOverride("margin_right", 8);
+        margin.SetAnchorsAndOffsetsPreset(Control.LayoutPreset.FullRect);
+        AddChild(margin);
+
+        var vbox = new VBoxContainer();
+        margin.AddChild(vbox);
+
+        var headerLabel = new Label { Text = "Installed Language Extensions" };
+        vbox.AddChild(headerLabel);
+
+        _extensionList = new ItemList
+        {
+            SizeFlagsVertical = Control.SizeFlags.ExpandFill,
+            CustomMinimumSize = new Vector2(0, 200)
+        };
+        _extensionList.ItemSelected += _ => UpdateButtonStates();
+        vbox.AddChild(_extensionList);
+
+        var buttonRow = new HBoxContainer();
+        vbox.AddChild(buttonRow);
+
+        _installButton = new Button { Text = "Install (.vsix)…" };
+        _installButton.Pressed += OnInstallPressed;
+        buttonRow.AddChild(_installButton);
+
+        _uninstallButton = new Button { Text = "Uninstall" };
+        _uninstallButton.Pressed += OnUninstallPressed;
+        _uninstallButton.Disabled = true;
+        buttonRow.AddChild(_uninstallButton);
+
+        _statusLabel = new Label
+        {
+            Text = string.Empty,
+            AutowrapMode = TextServer.AutowrapMode.WordSmart,
+            SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
+        };
+        vbox.AddChild(_statusLabel);
+
+        // File dialog for picking .vsix
+        _vsixFileDialog = new FileDialog
+        {
+            FileMode = FileDialog.FileModeEnum.OpenFile,
+            Access = FileDialog.AccessEnum.Filesystem,
+            Title = "Select VS Code or Visual Studio Extension"
+        };
+        _vsixFileDialog.AddFilter("*.vsix", "VS Code or Visual Studio Extension");
+        _vsixFileDialog.FileSelected += OnVsixFileSelected;
+        AddChild(_vsixFileDialog);
+    }
+
+    private void PopulateList()
+    {
+        _extensionList.Clear();
+        foreach (var ext in _languageExtensionRegistry.GetAllExtensions())
+        {
+            var extensions = ext.Languages.SelectMany(l => l.FileExtensions).Distinct().ToList();
+            var extLabel = extensions.Count > 0 ? string.Join(", ", extensions) : "no file types";
+            var packageBadge = ext.PackageKind switch
+            {
+                ExtensionPackageKind.VSCode => "VS Code",
+                _ => "VS"
+            };
+            _extensionList.AddItem($"{ext.DisplayName} [{packageBadge}] v{ext.Version}  [{extLabel}]");
+        }
+        UpdateButtonStates();
+    }
+
+    private void UpdateButtonStates()
+    {
+        _uninstallButton.Disabled = _extensionList.GetSelectedItems().Length == 0;
+    }
+
+    private void OnInstallPressed()
+    {
+        _vsixFileDialog.PopupCentered(new Vector2I(700, 400));
+    }
+
+    private void OnVsixFileSelected(string path)
+    {
+        _installButton.Disabled = true;
+        _statusLabel.Text = $"Installing {System.IO.Path.GetFileName(path)}…";
+
+        _ = System.Threading.Tasks.Task.GodotRun(async () =>
+        {
+            try
+            {
+                var installed = await System.Threading.Tasks.Task.Run(() => _extensionInstaller.Install(path));
+                await this.InvokeAsync(() =>
+                {
+                    _statusLabel.Text = $"Installed '{installed.DisplayName}' successfully.";
+                    PopulateList();
+                    _installButton.Disabled = false;
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Extension install failed for {Path}", path);
+                await this.InvokeAsync(() =>
+                {
+                    _statusLabel.Text = $"Install failed: {ex.Message}";
+                    _installButton.Disabled = false;
+                });
+            }
+        });
+    }
+
+    private void OnUninstallPressed()
+    {
+        var selected = _extensionList.GetSelectedItems();
+        if (selected.Length == 0) return;
+
+        var index = selected[0];
+        var extensions = _languageExtensionRegistry.GetAllExtensions();
+        if (index >= extensions.Count) return;
+
+        var extensionId = extensions[index].Id;
+        var displayName = extensions[index].DisplayName;
+        try
+        {
+            _extensionInstaller.Uninstall(extensionId);
+            _statusLabel.Text = $"Uninstalled '{displayName}'.";
+            PopulateList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Extension uninstall failed for {Id}", extensionId);
+            _statusLabel.Text = $"Uninstall failed: {ex.Message}";
+        }
+    }
+}

--- a/src/SharpIDE.Godot/Features/Settings/SettingsWindow.cs
+++ b/src/SharpIDE.Godot/Features/Settings/SettingsWindow.cs
@@ -1,4 +1,5 @@
 using Godot;
+using SharpIDE.Godot.Features.ExtensionManager;
 using SharpIDE.Godot.Features.IdeSettings;
 
 namespace SharpIDE.Godot.Features.Settings;
@@ -9,6 +10,7 @@ public partial class SettingsWindow : Window
     private LineEdit _debuggerFilePathLineEdit = null!;
     private CheckButton _debuggerUseSharpDbgCheckButton = null!;
     private OptionButton _themeOptionButton = null!;
+    private ExtensionManagerWindow? _extensionManagerWindow;
     
     public override void _Ready()
     {
@@ -22,6 +24,34 @@ public partial class SettingsWindow : Window
         _debuggerUseSharpDbgCheckButton.Toggled += OnDebuggerUseSharpDbgToggled;
         _themeOptionButton.ItemSelected += OnThemeItemSelected;
         AboutToPopup += OnAboutToPopup;
+        AddLanguageExtensionsControls();
+    }
+
+    private void AddLanguageExtensionsControls()
+    {
+        var settingsVBox = _uiScaleSpinBox.GetParent()?.GetParent()?.GetParent<VBoxContainer>();
+        if (settingsVBox == null)
+        {
+            return;
+        }
+
+        settingsVBox.AddChild(new HSeparator());
+        settingsVBox.AddChild(new Label { Text = "Language Extensions" });
+
+        var manageButton = new Button { Text = "Manage Extensions..." };
+        manageButton.Pressed += OnManageExtensionsPressed;
+        settingsVBox.AddChild(manageButton);
+    }
+
+    private void OnManageExtensionsPressed()
+    {
+        if (_extensionManagerWindow == null)
+        {
+            _extensionManagerWindow = new ExtensionManagerWindow();
+            AddChild(_extensionManagerWindow);
+        }
+
+        _extensionManagerWindow.PopupCentered(new Vector2I(540, 380));
     }
 
     private void OnAboutToPopup()

--- a/src/SharpIDE.Godot/Features/SolutionExplorer/ContextMenus/FolderContextMenu.cs
+++ b/src/SharpIDE.Godot/Features/SolutionExplorer/ContextMenus/FolderContextMenu.cs
@@ -1,5 +1,6 @@
 ﻿using Godot;
 using SharpIDE.Application.Features.FileWatching;
+using SharpIDE.Application.Features.LanguageExtensions;
 using SharpIDE.Application.Features.SolutionDiscovery;
 using SharpIDE.Godot.Features.SolutionExplorer.ContextMenus.Dialogs;
 
@@ -22,6 +23,7 @@ file enum CreateNewSubmenuOptions
 public partial class SolutionExplorerPanel
 {
     [Inject] private readonly IdeFileOperationsService _ideFileOperationsService = null!;
+    [Inject] private readonly LanguageExtensionRegistry _languageExtensionRegistry = null!;
     
     private readonly PackedScene _newDirectoryDialogScene = GD.Load<PackedScene>("uid://bgi4u18y8pt4x");
     private readonly PackedScene _newCsharpFileDialogScene = GD.Load<PackedScene>("uid://chnb7gmcdg0ww");
@@ -35,7 +37,17 @@ public partial class SolutionExplorerPanel
         menu.AddSubmenuNodeItem("Add", createNewSubmenu, (int)FolderContextMenuOptions.CreateNew);
         createNewSubmenu.AddItem("Directory", (int)CreateNewSubmenuOptions.Directory);
         createNewSubmenu.AddItem("C# File", (int)CreateNewSubmenuOptions.CSharpFile);
-        createNewSubmenu.IdPressed += id => OnCreateNewSubmenuPressed(id, folder);
+        var extensionItems = BuildExtensionMenuItems(createNewSubmenu);
+        createNewSubmenu.IdPressed += id =>
+        {
+            if (extensionItems.TryGetValue((int)id, out var extension))
+            {
+                ShowNewExtensionFileDialog(folder, extension);
+                return;
+            }
+
+            OnCreateNewSubmenuPressed(id, folder);
+        };
         
         menu.AddItem("Reveal in File Explorer", (int)FolderContextMenuOptions.RevealInFileExplorer);
         menu.AddItem("Delete", (int)FolderContextMenuOptions.Delete);
@@ -104,5 +116,70 @@ public partial class SolutionExplorerPanel
             AddChild(newCsharpFileDialog);
             newCsharpFileDialog.PopupCentered();
         }
+    }
+
+    private Dictionary<int, string> BuildExtensionMenuItems(PopupMenu submenu)
+    {
+        var items = new Dictionary<int, string>();
+        var nextId = 100;
+        var seenExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var extension in _languageExtensionRegistry.GetAllExtensions())
+        {
+            foreach (var language in extension.Languages)
+            {
+                foreach (var fileExtension in language.FileExtensions)
+                {
+                    if (seenExtensions.Add(fileExtension) is false)
+                    {
+                        continue;
+                    }
+
+                    submenu.AddItem($"{fileExtension.TrimStart('.').ToUpperInvariant()} File", nextId);
+                    items[nextId] = fileExtension;
+                    nextId++;
+                }
+            }
+        }
+
+        return items;
+    }
+
+    private void ShowNewExtensionFileDialog(SharpIdeFolder parentFolder, string fileExtension)
+    {
+        var extensionName = fileExtension.TrimStart('.').ToUpperInvariant();
+        var dialog = new ConfirmationDialog
+        {
+            Title = $"New {extensionName} File",
+            MinSize = new Vector2I(340, 0)
+        };
+        var lineEdit = new LineEdit
+        {
+            Text = $"Template{fileExtension}",
+            CustomMinimumSize = new Vector2(300, 0),
+            SelectAllOnFocus = true
+        };
+        dialog.AddChild(lineEdit);
+        dialog.Confirmed += () =>
+        {
+            var fileName = lineEdit.Text.Trim();
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return;
+            }
+
+            if (fileName.EndsWith(fileExtension, StringComparison.OrdinalIgnoreCase) is false)
+            {
+                fileName += fileExtension;
+            }
+
+            _ = Task.GodotRun(async () =>
+            {
+                var file = await _ideFileOperationsService.CreateGenericFile(parentFolder, fileName);
+                GodotGlobalEvents.Instance.FileExternallySelected.InvokeParallelFireAndForget(file, null);
+            });
+        };
+        AddChild(dialog);
+        dialog.PopupCentered();
     }
 }

--- a/src/SharpIDE.Godot/Features/SolutionExplorer/ContextMenus/ProjectContextMenu.cs
+++ b/src/SharpIDE.Godot/Features/SolutionExplorer/ContextMenus/ProjectContextMenu.cs
@@ -47,6 +47,17 @@ public partial class SolutionExplorerPanel
         createNewSubmenu.AddItem("Directory", (int)CreateNewSubmenuOptions.Directory);
         createNewSubmenu.AddItem("C# File", (int)CreateNewSubmenuOptions.CSharpFile);
         createNewSubmenu.IdPressed += id => OnCreateNewSubmenuPressed(id, project.Folder);
+        var extensionItems = BuildExtensionMenuItems(createNewSubmenu);
+        createNewSubmenu.IdPressed += id =>
+        {
+            if (extensionItems.TryGetValue((int)id, out var extension))
+            {
+                ShowNewExtensionFileDialog(project.Folder, extension);
+                return;
+            }
+
+            OnCreateNewSubmenuPressed(id, project.Folder);
+        };
 
         if (project is { IsLoaded: true, IsRunnable: true })
         {

--- a/src/SharpIDE.Godot/IdeRoot.cs
+++ b/src/SharpIDE.Godot/IdeRoot.cs
@@ -7,6 +7,7 @@ using SharpIDE.Application.Features.Events;
 using SharpIDE.Application.Features.FilePersistence;
 using SharpIDE.Application.Features.FileSystem;
 using SharpIDE.Application.Features.FileWatching;
+using SharpIDE.Application.Features.LanguageExtensions;
 using SharpIDE.Application.Features.NavigationHistory;
 using SharpIDE.Application.Features.Run;
 using SharpIDE.Application.Features.SolutionDiscovery;
@@ -54,6 +55,7 @@ public partial class IdeRoot : Control
     [Inject] private readonly IdeNavigationHistoryService _navigationHistoryService = null!;
     [Inject] private readonly SharpIdeSolutionService _sharpIdeSolutionService = null!;
     [Inject] private readonly ILogger<IdeRoot> _logger = null!;
+    [Inject] private readonly LanguageExtensionRegistry _languageExtensionRegistry = null!;
 
 	public override void _EnterTree()
 	{
@@ -85,6 +87,7 @@ public partial class IdeRoot : Control
 		_invertedVSplitContainer = GetNode<InvertedVSplitContainer>("%InvertedVSplitContainer");
 		_bottomPanelManager = GetNode<BottomPanelManager>("%BottomPanel");
 		
+		LoadLanguageExtensionRegistry();
 		_runMenuButton.Pressed += OnRunMenuButtonPressed;
 		GodotGlobalEvents.Instance.FileSelected.Subscribe(OnSolutionExplorerPanelOnFileSelected);
 		_openSlnButton.Pressed += () => IdeWindow.PickSolution();
@@ -98,6 +101,24 @@ public partial class IdeRoot : Control
 		GodotGlobalEvents.Instance.BottomPanelVisibilityChangeRequested.Subscribe(async show => await this.InvokeAsync(() => _invertedVSplitContainer.InvertedSetCollapsed(!show)));
 		GetTree().GetRoot().FocusExited += OnFocusExited;
 		_nodeReadyTcs.SetResult();
+	}
+
+	private void LoadLanguageExtensionRegistry()
+	{
+		try
+		{
+			var extensions = LanguageExtensionPersistence.Load();
+			foreach (var extension in extensions)
+			{
+				_languageExtensionRegistry.Register(extension);
+			}
+
+			_logger.LogInformation("Loaded {Count} language extension(s) from registry", extensions.Count);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning(ex, "Failed to load language extension registry");
+		}
 	}
 
 	private async Task OnBuildStarted(BuildStartedFlags flags) => await OnBuildRunningStateChanged(true, flags);

--- a/src/SharpIDE.Godot/SharpIDE.Godot.csproj
+++ b/src/SharpIDE.Godot/SharpIDE.Godot.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="ObservableCollections" />
     <PackageReference Include="ObservableCollections.R3" />
     <PackageReference Include="R3" />
+    <PackageReference Include="TextMateSharp" />
     <PackageReference Include="Krafs.Publicizer">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/SharpIDE.Application.IntegrationTests/Features/LanguageExtensions/VsixPackageParserTests.cs
+++ b/tests/SharpIDE.Application.IntegrationTests/Features/LanguageExtensions/VsixPackageParserTests.cs
@@ -1,0 +1,281 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using SharpIDE.Application.Features.LanguageExtensions;
+
+namespace SharpIDE.Application.IntegrationTests.Features.LanguageExtensions;
+
+public class VsixPackageParserTests : IDisposable
+{
+    private const string ExtensionsDirectoryEnvironmentVariable = "SHARPIDE_EXTENSIONS_BASE_DIRECTORY";
+    private readonly string? _originalExtensionsDirectory = Environment.GetEnvironmentVariable(ExtensionsDirectoryEnvironmentVariable);
+    private readonly string _testExtensionsDirectory = Directory.CreateTempSubdirectory("sharpide-language-extensions-tests-").FullName;
+
+    public VsixPackageParserTests()
+    {
+        Environment.SetEnvironmentVariable(ExtensionsDirectoryEnvironmentVariable, _testExtensionsDirectory);
+    }
+
+    [Fact]
+    public void Parse_VisualStudioVsix_FindsExpectedGrammarAndFileExtensions()
+    {
+        var vsixPath = CreateVisualStudioVsix();
+
+        var result = VsixPackageParser.Parse(vsixPath);
+
+        result.Id.Should().Be("sharpide.testlang");
+        result.DisplayName.Should().Be("SharpIDE Test Language");
+        result.PackageKind.Should().Be(ExtensionPackageKind.VisualStudio);
+        result.Grammars.Should().Contain(g =>
+            g.GrammarFilePath.EndsWith("testlang.tmLanguage", StringComparison.OrdinalIgnoreCase));
+
+        var allExtensions = result.Languages.SelectMany(language => language.FileExtensions).ToArray();
+        allExtensions.Should().Contain(".testlang");
+        allExtensions.Should().Contain(".testlanginc");
+        allExtensions.Should().Contain(".testlangextra");
+    }
+
+    [Fact]
+    public void Parse_VsCodeVsix_FindsLanguageAndGrammarContributions()
+    {
+        var vsixPath = CreateVsCodeVsix();
+
+        var result = VsixPackageParser.Parse(vsixPath);
+
+        result.Id.Should().Be("trond-snekvik.simple-rst");
+        result.PackageKind.Should().Be(ExtensionPackageKind.VSCode);
+        result.Languages.Should().ContainSingle(language =>
+            language.LanguageId == "restructuredtext" &&
+            language.FileExtensions.Contains(".rst"));
+        result.Grammars.Should().ContainSingle(grammar =>
+            grammar.LanguageId == "restructuredtext" &&
+            grammar.ScopeName == "source.rst" &&
+            grammar.GrammarFilePath == "extension/syntaxes/rst.tmLanguage.json");
+    }
+
+    [Fact]
+    public void Install_RegistersGrammarAndResolvesAbsoluteGrammarPath()
+    {
+        var vsixPath = CreateVisualStudioVsix();
+        var registry = new LanguageExtensionRegistry();
+        var installer = new ExtensionInstaller(registry, NullLogger<ExtensionInstaller>.Instance);
+
+        var installed = installer.Install(vsixPath);
+
+        installed.ExtractedPath.Should().StartWith(_testExtensionsDirectory);
+        installed.Grammars.Should().NotBeEmpty();
+        installed.Grammars.Should().OnlyContain(grammar => Path.IsPathRooted(grammar.GrammarFilePath));
+        registry.GetGrammar(".testlangextra").Should().NotBeNull();
+        File.Exists(registry.GetGrammar(".testlangextra")!.GrammarFilePath).Should().BeTrue();
+        File.Exists(Path.Combine(_testExtensionsDirectory, "registry.json")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Install_RejectsPackagesWithoutTextMateGrammar()
+    {
+        var vsixPath = CreateVsCodeVsixWithoutGrammar();
+        var registry = new LanguageExtensionRegistry();
+        var installer = new ExtensionInstaller(registry, NullLogger<ExtensionInstaller>.Instance);
+
+        var act = () => installer.Install(vsixPath);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*does not contain any importable TextMate syntax files*");
+        registry.GetAllExtensions().Should().BeEmpty();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(ExtensionsDirectoryEnvironmentVariable, _originalExtensionsDirectory);
+        if (Directory.Exists(_testExtensionsDirectory))
+        {
+            Directory.Delete(_testExtensionsDirectory, recursive: true);
+        }
+    }
+
+    private static string CreateVsCodeVsix()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("sharpide-vscode-vsix-test-");
+        var vsixPath = Path.Combine(tempDir.FullName, "simple-rst.vsix");
+
+        using var archive = System.IO.Compression.ZipFile.Open(vsixPath, System.IO.Compression.ZipArchiveMode.Create);
+
+        var manifestEntry = archive.CreateEntry("extension.vsixmanifest");
+        using (var writer = new StreamWriter(manifestEntry.Open()))
+        {
+            writer.Write(
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
+                  <Metadata>
+                    <Identity Language="en-US" Id="simple-rst" Version="1.5.4" Publisher="trond-snekvik" />
+                    <DisplayName>reStructuredText Syntax highlighting</DisplayName>
+                  </Metadata>
+                  <Installation>
+                    <InstallationTarget Id="Microsoft.VisualStudio.Code" />
+                  </Installation>
+                  <Assets>
+                    <Asset Type="Microsoft.VisualStudio.Code.Manifest" Path="extension/package.json" Addressable="true" />
+                  </Assets>
+                </PackageManifest>
+                """);
+        }
+
+        var packageEntry = archive.CreateEntry("extension/package.json");
+        using (var writer = new StreamWriter(packageEntry.Open()))
+        {
+            writer.Write(
+                """
+                {
+                  "name": "simple-rst",
+                  "displayName": "reStructuredText Syntax highlighting",
+                  "publisher": "trond-snekvik",
+                  "version": "1.5.4",
+                  "contributes": {
+                    "languages": [
+                      {
+                        "id": "restructuredtext",
+                        "extensions": [".rst"]
+                      }
+                    ],
+                    "grammars": [
+                      {
+                        "language": "restructuredtext",
+                        "scopeName": "source.rst",
+                        "path": "./syntaxes/rst.tmLanguage.json"
+                      }
+                    ]
+                  }
+                }
+                """);
+        }
+
+        var grammarEntry = archive.CreateEntry("extension/syntaxes/rst.tmLanguage.json");
+        using (var writer = new StreamWriter(grammarEntry.Open()))
+        {
+            writer.Write(
+                """
+                {
+                  "scopeName": "source.rst",
+                  "fileTypes": ["rst"],
+                  "patterns": []
+                }
+                """);
+        }
+
+        return vsixPath;
+    }
+
+    private static string CreateVisualStudioVsix()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("sharpide-visualstudio-vsix-test-");
+        var vsixPath = Path.Combine(tempDir.FullName, "testlang.vsix");
+
+        using var archive = System.IO.Compression.ZipFile.Open(vsixPath, System.IO.Compression.ZipArchiveMode.Create);
+
+        var manifestEntry = archive.CreateEntry("extension.vsixmanifest");
+        using (var writer = new StreamWriter(manifestEntry.Open()))
+        {
+            writer.Write(
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
+                  <Metadata>
+                    <Identity Language="en-US" Id="sharpide.testlang" Version="1.0.0" Publisher="SharpIDE Tests" />
+                    <DisplayName>SharpIDE Test Language</DisplayName>
+                  </Metadata>
+                  <Installation>
+                    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)" />
+                  </Installation>
+                  <Assets>
+                    <Asset Type="Microsoft.VisualStudio.VsPackage" Path="TestLanguage.pkgdef" />
+                  </Assets>
+                </PackageManifest>
+                """);
+        }
+
+        var pkgdefEntry = archive.CreateEntry("TestLanguage.pkgdef");
+        using (var writer = new StreamWriter(pkgdefEntry.Open()))
+        {
+            writer.Write(
+                """
+                [$RootKey$\TextMate\Repositories]
+                "testlang"="$PackageFolder$\Syntaxes"
+                [$RootKey$\ShellFileAssociations\.testlang]
+                "TestLanguage"=dword:00000064
+                [$RootKey$\ShellFileAssociations\.testlanginc]
+                "TestLanguage"=dword:00000064
+                ;[$RootKey$\ShellFileAssociations\.testlangextra]
+                ;"TestLanguage"=dword:00000064
+                """);
+        }
+
+        var grammarEntry = archive.CreateEntry("Syntaxes/testlang.tmLanguage");
+        using (var writer = new StreamWriter(grammarEntry.Open()))
+        {
+            writer.Write(
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                <plist version="1.0">
+                  <dict>
+                    <key>scopeName</key>
+                    <string>source.testlang</string>
+                    <key>fileTypes</key>
+                    <array>
+                      <string>testlangextra</string>
+                    </array>
+                    <key>patterns</key>
+                    <array />
+                  </dict>
+                </plist>
+                """);
+        }
+
+        return vsixPath;
+    }
+
+    private static string CreateVsCodeVsixWithoutGrammar()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("sharpide-vscode-vsix-test-");
+        var vsixPath = Path.Combine(tempDir.FullName, "no-grammar.vsix");
+        var suffix = Guid.NewGuid().ToString("N");
+
+        using var archive = System.IO.Compression.ZipFile.Open(vsixPath, System.IO.Compression.ZipArchiveMode.Create);
+
+        var manifestEntry = archive.CreateEntry("extension.vsixmanifest");
+        using (var writer = new StreamWriter(manifestEntry.Open()))
+        {
+            writer.Write(
+                $$"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
+                  <Metadata>
+                    <Identity Language="en-US" Id="no-grammar-{{suffix}}" Version="1.0.0" Publisher="sharpide-tests" />
+                    <DisplayName>No Grammar Test</DisplayName>
+                  </Metadata>
+                  <Installation>
+                    <InstallationTarget Id="Microsoft.VisualStudio.Code" />
+                  </Installation>
+                  <Assets>
+                    <Asset Type="Microsoft.VisualStudio.Code.Manifest" Path="extension/package.json" Addressable="true" />
+                  </Assets>
+                </PackageManifest>
+                """);
+        }
+
+        var packageEntry = archive.CreateEntry("extension/package.json");
+        using (var writer = new StreamWriter(packageEntry.Open()))
+        {
+            writer.Write(
+                $$"""
+                {
+                  "name": "no-grammar-{{suffix}}",
+                  "displayName": "No Grammar Test",
+                  "publisher": "sharpide-tests",
+                  "version": "1.0.0"
+                }
+                """);
+        }
+
+        return vsixPath;
+    }
+}


### PR DESCRIPTION
1. Allow SharpIDE to import existing VS for Windows .vsix files, but limit the imported items to just TextMate based syntax file now. (T4Language.vsix for example)
2. Add TextMate syntax highlighting engine to code editor. (T4 highlighting, include C#/VB.NET best effort detection)
3. Allow SharpIDE to create generic files with language specific extensions based on the imported language specification. (.tt and others)
4. Add a prototype UI in Settings to manage imported extensions

<!-- PR description above this line -->
#
> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/SharpIDE/blob/main/CONTRIBUTING.md#legal-notice)
